### PR TITLE
fix: OnDatapackSyncEvent not being fired do to missing static accessor

### DIFF
--- a/src/main/java/nova/committee/avaritia/common/item/singularity/Singularity.java
+++ b/src/main/java/nova/committee/avaritia/common/item/singularity/Singularity.java
@@ -23,6 +23,7 @@ public class Singularity {
     private final int timeRequired;
     private Ingredient ingredient;
     private boolean enabled = true;
+    private boolean recipeDisabled = false;
 
     public Singularity(ResourceLocation id, String name, int[] colors, Ingredient ingredient, int ingredientCount, int timeRequired) {
         this.id = id;
@@ -132,6 +133,14 @@ public class Singularity {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public boolean isRecipeDisabled() {
+        return recipeDisabled;
+    }
+
+    public void setRecipeDisabled(boolean recipeDisabled) {
+        this.recipeDisabled = recipeDisabled;
     }
 
     public void write(FriendlyByteBuf buffer) {

--- a/src/main/java/nova/committee/avaritia/init/handler/DynamicRecipeHandler.java
+++ b/src/main/java/nova/committee/avaritia/init/handler/DynamicRecipeHandler.java
@@ -26,16 +26,16 @@ import java.util.List;
 public class DynamicRecipeHandler {
     @SubscribeEvent
     public static void onRegisterRecipes(RegisterRecipesEvent event) {
-
         for (var singularity : SingularityRegistryHandler.getInstance().getSingularities()) {
+            if (singularity.isRecipeDisabled()) {
+                continue;
+            }
+
             var compressorRecipe = makeSingularityRecipe(singularity);
 
             if (compressorRecipe != null)
                 event.register(compressorRecipe);
         }
-
-
-
     }
 
 

--- a/src/main/java/nova/committee/avaritia/init/handler/SingularityRegistryHandler.java
+++ b/src/main/java/nova/committee/avaritia/init/handler/SingularityRegistryHandler.java
@@ -14,6 +14,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.loading.FMLPaths;
 import net.minecraftforge.network.PacketDistributor;
+import nova.committee.avaritia.Avaritia;
 import nova.committee.avaritia.Static;
 import nova.committee.avaritia.common.item.singularity.Singularity;
 import nova.committee.avaritia.common.net.SyncSingularitiesPacket;
@@ -37,7 +38,7 @@ import java.util.stream.Collectors;
  * Date: 2022/4/2 12:35
  * Version: 1.0
  */
-@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE)
+@Mod.EventBusSubscriber
 public class SingularityRegistryHandler {
     private static final SingularityRegistryHandler INSTANCE = new SingularityRegistryHandler();
     private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().create();
@@ -49,8 +50,8 @@ public class SingularityRegistryHandler {
     }
 
     @SubscribeEvent
-    public void onDatapackSync(OnDatapackSyncEvent event) {
-        var message = new SyncSingularitiesPacket(this.getSingularities());
+    public static void onDatapackSync(OnDatapackSyncEvent event) {
+        var message = new SyncSingularitiesPacket(SingularityRegistryHandler.getInstance().getSingularities());
         var player = event.getPlayer();
 
         if (player != null) {

--- a/src/main/java/nova/committee/avaritia/init/handler/SingularityRegistryHandler.java
+++ b/src/main/java/nova/committee/avaritia/init/handler/SingularityRegistryHandler.java
@@ -14,7 +14,6 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.loading.FMLPaths;
 import net.minecraftforge.network.PacketDistributor;
-import nova.committee.avaritia.Avaritia;
 import nova.committee.avaritia.Static;
 import nova.committee.avaritia.common.item.singularity.Singularity;
 import nova.committee.avaritia.common.net.SyncSingularitiesPacket;

--- a/src/main/java/nova/committee/avaritia/util/SingularityUtils.java
+++ b/src/main/java/nova/committee/avaritia/util/SingularityUtils.java
@@ -54,8 +54,10 @@ public class SingularityUtils {
         }
 
         var enabled = GsonHelper.getAsBoolean(json, "enabled", true);
+        var recipeDisabled = GsonHelper.getAsBoolean(json, "recipeDisabled", false);
 
         singularity.setEnabled(enabled);
+        singularity.setRecipeDisabled(recipeDisabled);
 
         return singularity;
     }


### PR DESCRIPTION
Fixes #22 

- Fixed the data sync event not being fired
- Added a `recipeDisabled` property to the .json spec for singularities to bypass recipe registration for modpack authors that wish to keep the singularity but not the recipes.