### PR TITLE
修复奇点计时器导致游戏无法中断

### DIFF
--- a/src/main/java/committee/nova/mods/avaritia/client/AvaritiaForgeClient.java
+++ b/src/main/java/committee/nova/mods/avaritia/client/AvaritiaForgeClient.java
@@ -6,6 +6,7 @@ import committee.nova.mods.avaritia.api.client.screen.ItemFilterScreen;
 import committee.nova.mods.avaritia.api.iface.IFilterItem;
 import committee.nova.mods.avaritia.client.screen.AvaritiaConfigScreen;
 import committee.nova.mods.avaritia.common.entity.GapingVoidEntity;
+import committee.nova.mods.avaritia.common.item.singularity.SingularityItem;
 import committee.nova.mods.avaritia.init.config.ModConfig;
 import committee.nova.mods.avaritia.init.registry.ModItems;
 import net.minecraft.client.KeyMapping;
@@ -94,6 +95,8 @@ public class AvaritiaForgeClient {
 
         //计算黑暗强度
         calculateDarknessIntensity(player, level);
+
+        singularityIconTimer();
     }
 
     /**
@@ -266,6 +269,12 @@ public class AvaritiaForgeClient {
         }
     }
 
+    private static void singularityIconTimer(){
+        if (renderTime % 20 != 0) return;
+        if (SingularityItem.enabledSingularities != null && !SingularityItem.enabledSingularities.isEmpty()) {
+            SingularityItem.currentSingularityIndex.set((SingularityItem.currentSingularityIndex.get() + 1) % SingularityItem.enabledSingularities.size());
+        }
+    }
 
     @SubscribeEvent
     public static void onRenderTickStart(TickEvent.RenderTickEvent event) {

--- a/src/main/java/committee/nova/mods/avaritia/common/item/singularity/SingularityItem.java
+++ b/src/main/java/committee/nova/mods/avaritia/common/item/singularity/SingularityItem.java
@@ -22,26 +22,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class SingularityItem extends Item implements IColored {
-    private static final AtomicInteger currentSingularityIndex = new AtomicInteger(0);
-    private static final Timer singularityIconTimer = new Timer("Singularity Icon Timer");
-    private static List<Singularity> enabledSingularities = null;
 
-    static {
-        // 初始化定时器，每秒切换一次奇点显示
-        singularityIconTimer.scheduleAtFixedRate(new TimerTask() {
-            @Override
-            public void run() {
-                if (enabledSingularities != null && !enabledSingularities.isEmpty()) {
-                    currentSingularityIndex.set((currentSingularityIndex.get() + 1) % enabledSingularities.size());
-                }
-            }
-        }, 0, 1000); // 每1秒切换一次
-    }
+    public static final AtomicInteger currentSingularityIndex = new AtomicInteger(0);
+    public static List<Singularity> enabledSingularities = null;
 
     public SingularityItem() {
         super(new Properties().rarity(ModRarities.UNCOMMON));


### PR DESCRIPTION
<img width="1733" height="576" alt="f1ceaac2080ad38bd5de9f04b85fc2d8" src="https://github.com/user-attachments/assets/e8786e43-1eb5-493e-80ba-735f12c08a22" />
会卡住，并且双端都在调用，甚至数据生成都卡住

换成了跟随tick更新，仅客户端