### PR TITLE
补上screen对于image宽高的指定；添加jei与emi避让区兼容

### DIFF
--- a/src/main/java/committee/nova/mods/avaritia/client/screen/InfinityChestScreen.java
+++ b/src/main/java/committee/nova/mods/avaritia/client/screen/InfinityChestScreen.java
@@ -60,8 +60,10 @@ public class InfinityChestScreen extends BaseContainerScreen<InfinityChestMenu> 
     @Override
     protected void subInit() {
         super.subInit();
-        this.leftPos = (this.width - 302) / 2;
-        this.topPos = (this.height - 274) / 2;
+        this.imageWidth = 302;
+        this.imageHeight = 274;
+        this.leftPos = (this.width - this.imageWidth) / 2;
+        this.topPos = (this.height - this.imageHeight) / 2;
 
         this.scrollBar = new ItemScrollBar(leftPos + 282, topPos + 16, 12, 160);
         this.scrollBar.setScrolledOn(menu.chestContainer.getScrollOn());
@@ -76,6 +78,8 @@ public class InfinityChestScreen extends BaseContainerScreen<InfinityChestMenu> 
         this.searchBox.setValue(menu.filter);
         this.addRenderableWidget(searchBox);
         menu.chestContainer.refreshContainer(true);
+
+        // 创建两侧避让区
     }
 
     @Override

--- a/src/main/java/committee/nova/mods/avaritia/client/screen/element/GuiElementAccess.java
+++ b/src/main/java/committee/nova/mods/avaritia/client/screen/element/GuiElementAccess.java
@@ -1,0 +1,12 @@
+package committee.nova.mods.avaritia.client.screen.element;
+
+import net.minecraft.client.renderer.Rect2i;
+
+/** 添加一些自定义的，意图让外界获取的信息 */
+public interface GuiElementAccess
+{
+    /**
+     * 获取当前UI元素的所占的屏幕空间
+     */
+    Rect2i getElementArea();
+}

--- a/src/main/java/committee/nova/mods/avaritia/init/compat/emi/AvaritiaEmiPlugin.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/compat/emi/AvaritiaEmiPlugin.java
@@ -10,10 +10,7 @@ import committee.nova.mods.avaritia.init.compat.emi.category.tables.EndCraftingT
 import committee.nova.mods.avaritia.init.compat.emi.category.tables.ExtremeCraftingTableCategory;
 import committee.nova.mods.avaritia.init.compat.emi.category.tables.NetherCraftingTableCategory;
 import committee.nova.mods.avaritia.init.compat.emi.category.tables.SculkCraftingTableCategory;
-import committee.nova.mods.avaritia.init.compat.emi.handler.EndCraftingRecipeHandler;
-import committee.nova.mods.avaritia.init.compat.emi.handler.ExtremeCraftingRecipeHandler;
-import committee.nova.mods.avaritia.init.compat.emi.handler.NetherCraftingRecipeHandler;
-import committee.nova.mods.avaritia.init.compat.emi.handler.SculkCraftingRecipeHandler;
+import committee.nova.mods.avaritia.init.compat.emi.handler.*;
 import committee.nova.mods.avaritia.init.registry.ModBlocks;
 import committee.nova.mods.avaritia.init.registry.ModItems;
 import committee.nova.mods.avaritia.init.registry.ModMenus;
@@ -76,6 +73,8 @@ public class AvaritiaEmiPlugin implements EmiPlugin {
         registry.addRecipeHandler(ModMenus.nether_crafting_tile_table.get(), new NetherCraftingRecipeHandler());
         registry.addRecipeHandler(ModMenus.end_crafting_tile_table.get(), new EndCraftingRecipeHandler());
         registry.addRecipeHandler(ModMenus.extreme_crafting_table.get(), new ExtremeCraftingRecipeHandler());
+
+        registry.addGenericExclusionArea(new EMIExclusionZones());
 
     }
 }

--- a/src/main/java/committee/nova/mods/avaritia/init/compat/emi/handler/EMIExclusionZones.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/compat/emi/handler/EMIExclusionZones.java
@@ -1,0 +1,27 @@
+package committee.nova.mods.avaritia.init.compat.emi.handler;
+
+import committee.nova.mods.avaritia.api.client.screen.BaseContainerScreen;
+import committee.nova.mods.avaritia.client.screen.element.GuiElementAccess;
+import dev.emi.emi.api.EmiExclusionArea;
+import dev.emi.emi.api.widget.Bounds;
+import net.minecraft.client.gui.components.Renderable;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.renderer.Rect2i;
+
+import java.util.function.Consumer;
+
+public class EMIExclusionZones implements EmiExclusionArea<Screen> {
+
+    @Override
+    public void addExclusionArea(Screen screen, Consumer<Bounds> consumer) {
+        if(screen instanceof BaseContainerScreen<?>) {
+            // 仅为可渲染元素创造避让区域
+            for(Renderable renderable: screen.renderables) {
+                if(renderable instanceof GuiElementAccess access) {
+                    Rect2i area = access.getElementArea();
+                    consumer.accept(new Bounds(area.getX(), area.getY(), area.getWidth(), area.getHeight()));
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/committee/nova/mods/avaritia/init/compat/jei/AvaritiaJeiPlugin.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/compat/jei/AvaritiaJeiPlugin.java
@@ -1,6 +1,7 @@
 package committee.nova.mods.avaritia.init.compat.jei;
 
 import committee.nova.mods.avaritia.Const;
+import committee.nova.mods.avaritia.api.client.screen.BaseContainerScreen;
 import committee.nova.mods.avaritia.client.screen.ExtremeAnvilScreen;
 import committee.nova.mods.avaritia.client.screen.ExtremeSmithingScreen;
 import committee.nova.mods.avaritia.client.screen.NeutronCompressorScreen;
@@ -19,6 +20,7 @@ import committee.nova.mods.avaritia.init.compat.jei.category.tables.EndCraftingT
 import committee.nova.mods.avaritia.init.compat.jei.category.tables.ExtremeCraftingTableCategory;
 import committee.nova.mods.avaritia.init.compat.jei.category.tables.NetherCraftingTableCategory;
 import committee.nova.mods.avaritia.init.compat.jei.category.tables.SculkCraftingTableCategory;
+import committee.nova.mods.avaritia.init.compat.jei.handler.JeiContainerHandler;
 import committee.nova.mods.avaritia.init.registry.ModBlocks;
 import committee.nova.mods.avaritia.init.registry.ModItems;
 import committee.nova.mods.avaritia.init.registry.ModMenus;
@@ -124,6 +126,7 @@ public class AvaritiaJeiPlugin implements IModPlugin {
         registration.addRecipeClickArea(ExtremeCraftScreen.class, 174, 90, 22, 12, ExtremeCraftingTableCategory.RECIPE_TYPE);
         registration.addRecipeClickArea(ExtremeSmithingScreen.class, 86, 40, 22, 12, ExtremeSmithingRecipeCategory.RECIPE_TYPE);
         registration.addRecipeClickArea(ExtremeAnvilScreen.class, 102, 48, 22, 15, RecipeTypes.ANVIL);
+        registration.addGenericGuiContainerHandler(BaseContainerScreen.class, new JeiContainerHandler());
     }
 
     @Override

--- a/src/main/java/committee/nova/mods/avaritia/init/compat/jei/handler/JeiContainerHandler.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/compat/jei/handler/JeiContainerHandler.java
@@ -1,0 +1,27 @@
+package committee.nova.mods.avaritia.init.compat.jei.handler;
+
+import committee.nova.mods.avaritia.api.client.screen.BaseContainerScreen;
+import committee.nova.mods.avaritia.client.screen.element.GuiElementAccess;
+import mezz.jei.api.gui.handlers.IGuiContainerHandler;
+import net.minecraft.client.gui.components.Renderable;
+import net.minecraft.client.renderer.Rect2i;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class JeiContainerHandler implements IGuiContainerHandler<BaseContainerScreen<?>> {
+
+    /** 指定需要jei避让的区域 */
+    @Override
+    public @NotNull List<Rect2i> getGuiExtraAreas(BaseContainerScreen<?> containerScreen) {
+        List<Rect2i> areas = new ArrayList<>();
+        for(Renderable renderable : containerScreen.renderables) {
+            if(renderable instanceof GuiElementAccess access) {
+                areas.add(access.getElementArea());
+            }
+        }
+        return areas;
+    }
+}


### PR DESCRIPTION
主要是修复了无尽箱子screen中图片宽高未指定导致jei自动避让未生效的问题；
添加的jei与emi避让兼容目前未实际使用，但已经添加插件注册；
如果有任何ui元素位置在背景图之外，为其实现committee.nova.mods.avaritia.client.screen.element.GuiElementAccess后，jei与emi的元素会自动避让。