### PR TITLE
修复了未安装Curios时仍尝试读取Curios类的问题

### DIFF
--- a/src/main/java/committee/nova/mods/avaritia/api/util/InventoryUtils.java
+++ b/src/main/java/committee/nova/mods/avaritia/api/util/InventoryUtils.java
@@ -1,11 +1,7 @@
 package committee.nova.mods.avaritia.api.util;
 
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
+import committee.nova.mods.avaritia.init.compat.curios.CuriosTools;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.effect.MobEffectInstance;
-import net.minecraft.world.effect.MobEffects;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
@@ -14,10 +10,6 @@ import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.items.ItemHandlerHelper;
-import top.theillusivec4.curios.api.CuriosApi;
-import top.theillusivec4.curios.api.SlotContext;
-import top.theillusivec4.curios.api.SlotResult;
-import top.theillusivec4.curios.api.type.capability.ICurio;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -164,12 +156,10 @@ public class InventoryUtils {
      */
     public static ItemStack findItemInInv(Player player, Predicate<ItemStack> is, Function<ItemStack, ItemStack> map) {
         if (ModList.get().isLoaded("curios")) {
-            AtomicReference<List<SlotResult>> s = new AtomicReference<>(new ArrayList<>());
-            CuriosApi.getCuriosInventory(player).ifPresent(curiosInventory -> {
-                s.set(curiosInventory.findCurios(is));
-            });
-            if (!s.get().isEmpty()) return map.apply(s.get().get(0).stack());
-        }//从饰品栏中获取
+            ItemStack resultStack = CuriosTools.getFirstItemFromCuriosInv(player, is);
+            if (!resultStack.isEmpty()) return map.apply(resultStack);
+        }
+        //从饰品栏中获取
         if (is.test(player.getMainHandItem())) return map.apply(player.getMainHandItem());
         if (is.test(player.getOffhandItem())) return map.apply(player.getOffhandItem());
         Inventory inv = player.getInventory();
@@ -192,39 +182,7 @@ public class InventoryUtils {
      */
     public static ICapabilityProvider createCurioProvider(ItemStack stack, CompoundTag unused) {
         if (ModList.get().isLoaded("curios")) {
-            return CuriosApi.createCurioProvider(new ICurio() {
-                @Override
-                public ItemStack getStack() {
-                    return stack;
-                }
-
-                @Override
-                public void curioTick(SlotContext slotContext) {
-                    LivingEntity entity = slotContext.entity();
-                    if (entity instanceof Player player && !player.level().isClientSide) {
-
-                        player.addEffect(new MobEffectInstance(MobEffects.DIG_SPEED, -1, 2, false, true));
-                        player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SPEED, -1, 2, false, true));
-
-                        List<MobEffectInstance> effects = Lists.newArrayList(player.getActiveEffects());
-                        for (MobEffectInstance potion : Collections2.filter(effects, potion ->
-                                (potion.getEffect().equals(MobEffects.MOVEMENT_SLOWDOWN) ||
-                                        potion.getEffect().equals(MobEffects.DIG_SLOWDOWN)))) {
-                            player.removeEffect(potion.getEffect());
-                        }
-                    }
-                }
-
-                @Override
-                public boolean canEquip(SlotContext slotContext) {
-                    return true;
-                }
-
-                @Override
-                public boolean canUnequip(SlotContext slotContext) {
-                    return true;
-                }
-            });
+            return CuriosTools.getIDKCuriosProvider(stack);
         }
         return null;
     }

--- a/src/main/java/committee/nova/mods/avaritia/init/compat/curios/CuriosTools.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/compat/curios/CuriosTools.java
@@ -1,0 +1,64 @@
+package committee.nova.mods.avaritia.init.compat.curios;
+
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.SlotContext;
+import top.theillusivec4.curios.api.type.capability.ICurio;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class CuriosTools {
+
+    public static ItemStack getFirstItemFromCuriosInv(Player player, Predicate<ItemStack> is) {
+        return CuriosApi.getCuriosInventory(player)
+                .map(curiosInventory -> curiosInventory.findCurios(is).get(0).stack())
+                .orElse(ItemStack.EMPTY);
+    }
+
+    // TODO 我不知道原代码创建的CuriosProvider具体是做什么的，所以随便取了个方法名，稍后可以自己改一下
+    public static ICapabilityProvider getIDKCuriosProvider(ItemStack stack) {
+
+        return CuriosApi.createCurioProvider(new ICurio() {
+
+            @Override
+            public ItemStack getStack() {
+                return stack;
+            }
+
+            @Override
+            public void curioTick(SlotContext slotContext) {
+                LivingEntity entity = slotContext.entity();
+                if (entity instanceof Player player && !player.level().isClientSide) {
+                    player.addEffect(new MobEffectInstance(MobEffects.DIG_SPEED, -1, 2, false, true));
+                    player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SPEED, -1, 2, false, true));
+
+                    List<MobEffectInstance> effects = Lists.newArrayList(player.getActiveEffects());
+                    for (MobEffectInstance potion : Collections2.filter(effects, potion ->
+                            (potion.getEffect().equals(MobEffects.MOVEMENT_SLOWDOWN) ||
+                                    potion.getEffect().equals(MobEffects.DIG_SLOWDOWN)))) {
+                        player.removeEffect(potion.getEffect());
+                    }
+                }
+            }
+
+            @Override
+            public boolean canEquip(SlotContext slotContext) {
+                return true;
+            }
+
+            @Override
+            public boolean canUnequip(SlotContext slotContext) {
+                return true;
+            }
+        });
+
+    }
+}


### PR DESCRIPTION
原问题会在未安装Curios但身上携带无尽图腾死亡时发生（/kill不会复现此问题，需要自然死亡）