### PR TITLE
补齐CuriosTools中未导入的类

### DIFF
--- a/src/main/java/committee/nova/mods/avaritia/init/compat/curios/CuriosTools.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/compat/curios/CuriosTools.java
@@ -10,6 +10,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import top.theillusivec4.curios.api.CuriosApi;
 import top.theillusivec4.curios.api.SlotContext;
+import top.theillusivec4.curios.api.SlotResult;
 import top.theillusivec4.curios.api.type.capability.ICurio;
 
 import java.util.List;


### PR DESCRIPTION
#286 仍用于修复此问题
#287 此pr中未导入top.theillusivec4.curios.api.SlotResult类