### PR TITLE
导入1.20.1中有关压缩机同步状态的修复; 修复了无Curios运行时崩溃的问题

### DIFF
--- a/src/main/java/committee/nova/mods/avaritia/Avaritia.java
+++ b/src/main/java/committee/nova/mods/avaritia/Avaritia.java
@@ -1,15 +1,17 @@
 package committee.nova.mods.avaritia;
 
 import committee.nova.mods.avaritia.core.singularity.SingularityDataManager;
-import committee.nova.mods.avaritia.init.compat.projecte.ModEMCHandler;
+import committee.nova.mods.avaritia.init.compat.curios.AvaritiaCuriosPlugin;
 import committee.nova.mods.avaritia.init.config.ModConfig;
 import committee.nova.mods.avaritia.init.data.ModDataGen;
 import committee.nova.mods.avaritia.init.registry.*;
 import net.minecraft.world.level.block.DispenserBlock;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.ModList;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.neoforged.fml.event.lifecycle.FMLConstructModEvent;
 
 /**
  * @Project: Avaritia
@@ -20,7 +22,11 @@ import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 @Mod(Const.MOD_ID)
 public class Avaritia {
 
+    public static IEventBus MOD_EVENT_BUS;
+
     public Avaritia(IEventBus modEventBus, ModContainer modContainer) {
+        MOD_EVENT_BUS = modEventBus;
+
         ModConfig.register(modContainer);
 
 
@@ -39,8 +45,16 @@ public class Avaritia {
         ModRecipeSerializers.SERIALIZERS.register(modEventBus);
         ModIngredients.INGREDIENT.register(modEventBus);
 
+        modEventBus.addListener(this::constructMod);
         modEventBus.addListener(this::setup);
         modEventBus.addListener(ModDataGen::gatherData);
+    }
+
+    private void constructMod(final FMLConstructModEvent event)
+    {
+        if(ModList.get().isLoaded("curios")) {
+            MOD_EVENT_BUS.addListener(AvaritiaCuriosPlugin::registerCapabilities);
+        }
     }
 
     public void setup(final FMLCommonSetupEvent event) {

--- a/src/main/java/committee/nova/mods/avaritia/common/item/tools/crystal/CrystalShovelItem.java
+++ b/src/main/java/committee/nova/mods/avaritia/common/item/tools/crystal/CrystalShovelItem.java
@@ -8,14 +8,11 @@ import committee.nova.mods.avaritia.init.registry.ModToolTiers;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.ShovelItem;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
-import top.theillusivec4.curios.api.SlotContext;
-import top.theillusivec4.curios.api.type.capability.ICurioItem;
 
 import java.util.List;
 
@@ -25,7 +22,7 @@ import java.util.List;
  * Date: 2022/3/31 10:25
  * Version: 1.0
  */
-public class CrystalShovelItem extends ShovelItem implements ITooltip, ICurioItem {
+public class CrystalShovelItem extends ShovelItem implements ITooltip {
     public CrystalShovelItem() {
         super(ModToolTiers.CRYSTAL,
                 new Properties()
@@ -34,22 +31,6 @@ public class CrystalShovelItem extends ShovelItem implements ITooltip, ICurioIte
                         .fireResistant()
                         .attributes(createAttributes(ModToolTiers.CRYSTAL, 0, ModToolTiers.BLAZE.getSpeed()))
         );
-    }
-
-    @Override
-    public void curioTick(SlotContext slotContext, ItemStack stack) {
-        LivingEntity entity = slotContext.entity();
-        if (entity instanceof Player player && !player.level().isClientSide) {
-            player.addEffect(new MobEffectInstance(MobEffects.DIG_SPEED, -1, 2, false, true));
-            player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SPEED, -1, 2, false, true));
-
-            List<MobEffectInstance> effects = Lists.newArrayList(player.getActiveEffects());
-            for (MobEffectInstance potion : Collections2.filter(effects, potion ->
-                    (potion.getEffect().equals(MobEffects.MOVEMENT_SLOWDOWN) ||
-                            potion.getEffect().equals(MobEffects.DIG_SLOWDOWN)))) {
-                player.removeEffect(potion.getEffect());
-            }
-        }
     }
 
     @Override

--- a/src/main/java/committee/nova/mods/avaritia/common/tile/NeutronCompressorTile.java
+++ b/src/main/java/committee/nova/mods/avaritia/common/tile/NeutronCompressorTile.java
@@ -124,8 +124,7 @@ public class NeutronCompressorTile extends BaseInventoryTileEntity implements Wo
 
             if (recipe != null) {
                 if (tile.materialCount >= recipe.getInputCount() * tile.tier.inputAmplifier) {
-                    tile.progress++;
-                    tile.data.set(0, tile.progress);
+                    tile.setProgress(tile.progress + 1);
                     if (tile.progress >= recipe.getTimeCost() * tile.tier.timeAmplifier) {
 
                         CraftingInput craftingInput = tile.recipeInventory.toShapelessCraftingInput();
@@ -134,7 +133,7 @@ public class NeutronCompressorTile extends BaseInventoryTileEntity implements Wo
 
                         if (ItemUtils.canCombineStacks(result, output)) {
                             tile.updateResult(result);
-                            tile.progress = 0;
+                            tile.setProgress(0);
                             tile.materialCount -= Mth.ceil(recipe.getInputCount() * tile.tier.inputAmplifier);
 
                             if (tile.materialCount <= 0) {

--- a/src/main/java/committee/nova/mods/avaritia/init/compat/curios/AvaritiaCuriosPlugin.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/compat/curios/AvaritiaCuriosPlugin.java
@@ -1,0 +1,51 @@
+package committee.nova.mods.avaritia.init.compat.curios;
+
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
+import committee.nova.mods.avaritia.init.registry.ModItems;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+import top.theillusivec4.curios.api.CuriosCapability;
+import top.theillusivec4.curios.api.SlotContext;
+import top.theillusivec4.curios.api.type.capability.ICurio;
+
+import java.util.List;
+
+/** 为物品附加Curios能力，以及其他与Curios强相关的功能 */
+public class AvaritiaCuriosPlugin {
+
+    // 为物品附加饰品能力
+    public static void registerCapabilities(final RegisterCapabilitiesEvent evt) {
+        // 水晶铲子
+        evt.registerItem(
+                CuriosCapability.ITEM,
+                (stack, context) -> new ICurio() {
+                    @Override
+                    public ItemStack getStack() {
+                        return stack; // 必须返回传入的stack
+                    }
+
+                    @Override
+                    public void curioTick(SlotContext slotContext) {
+                        LivingEntity entity = slotContext.entity();
+                        if (entity instanceof Player player && !player.level().isClientSide) {
+                            player.addEffect(new MobEffectInstance(MobEffects.DIG_SPEED, -1, 2, false, true));
+                            player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SPEED, -1, 2, false, true));
+
+                            List<MobEffectInstance> effects = Lists.newArrayList(player.getActiveEffects());
+                            for (MobEffectInstance potion : Collections2.filter(effects, potion ->
+                                    (potion.getEffect().equals(MobEffects.MOVEMENT_SLOWDOWN) ||
+                                            potion.getEffect().equals(MobEffects.DIG_SLOWDOWN)))) {
+                                player.removeEffect(potion.getEffect());
+                            }
+                        }
+                    }
+                },
+                ModItems.crystal_shovel
+        );
+    }
+}


### PR DESCRIPTION
导入1.20.1中有关压缩机同步状态的修复：
    将遗漏的，未使用setter的赋值操作全部使用setter，以确保progress在menu打开时的任何修改都能被同步到客户端
修复了无Curios运行时崩溃的问题：
    水晶铲子不直接实现curios的接口，而使用能力系统动态附加，否则对于未安装curios的游戏，会直接崩溃