### PR TITLE
[Bug]尝试以一种懒惰的方式修复某种坏档NPE

### DIFF
--- a/src/main/java/committee/nova/mods/avaritia/common/tile/NeutronCompressorTile.java
+++ b/src/main/java/committee/nova/mods/avaritia/common/tile/NeutronCompressorTile.java
@@ -384,7 +384,7 @@ public class NeutronCompressorTile extends BaseInventoryTileEntity implements IT
 
             // 计算可转移的数量
             int maxTransfer = Math.min(stack.getCount(), 64); // 每次最多转移64个
-            int spaceInInput = materialStack.isEmpty() ? 64 : (int) (this.recipe.getInputCount() * this.tier.inputAmplifier - materialCount);
+            int spaceInInput = materialStack.isEmpty() || this.recipe == null ? 64 : (int) (this.recipe.getInputCount() * this.tier.inputAmplifier - materialCount);
 
             int inputCount = inputSlot.isEmpty() ? 64 : inputSlot.getMaxStackSize() - inputSlot.getCount();
 


### PR DESCRIPTION


### Checks / 检查
-->

- [X] I confirm that I have [searched for existing issues / pull requests](https://github.com/cnlimiter/McBot/issues?q=) before requesting to avoid duplicate requesting.  
      我确认在报告之前我已经搜索了[现有的问题或者拉取请求](https://github.com/cnlimiter/McBot/issues?q=)，以避免重复报告。
- [X] I confirm that I noted that if I don't follow the instructions, the issue may be closed directly.  
      我确认我已经检查，如果我不按照说明进行操作，该问题可能会被直接关闭。

### Related Issues / 相关的 GitHub 问题

Fix #322
(but in 1.20.1,just for me)

### Description / 描述
中子态素压缩机recipe为null导致NPE
(我也不记得怎么触发的了，当时我在拆压缩机，边上一堆暗物质台座给压缩机多跑了一堆#tick，压缩机本身还有主动输入和输出。处理一下null recipe之后就没有NPE了。)
 ---- Minecraft Crash Report ----
// Embeddium instance tainted by mods: [oculus]
// Please do not reach out for Embeddium support without removing these mods first.
// -------
// There are four lights!

Time: 2026-02-18 12:58:12
Description: Ticking block entity

java.lang.NullPointerException: Cannot invoke "committee.nova.mods.avaritia.api.common.crafting.ICompressorRecipe.getInputCount()" because "this.recipe" is null
	at committee.nova.mods.avaritia.common.tile.NeutronCompressorTile.extractFromHandler(NeutronCompressorTile.java:394) ~[%5B无尽贪婪：重生%5D%20Re-Avaritia-forge-1.20.1-1.3.9.6-release.jar%23310!/:?] {re:classloading}
	at committee.nova.mods.avaritia.core.io.TileIOHandler.lambda$handleActiveInput$0(TileIOHandler.java:112) ~[%5B无尽贪婪：重生%5D%20Re-Avaritia-forge-1.20.1-1.3.9.6-release.jar%23310!/:?] {re:classloading}
	at net.minecraftforge.common.util.LazyOptional.ifPresent(LazyOptional.java:137) ~[forge-1.20.1-47.4.16-universal.jar%23393!/:?] {re:mixin,re:classloading}
	at committee.nova.mods.avaritia.core.io.TileIOHandler.handleActiveInput(TileIOHandler.java:112) ~[%5B无尽贪婪：重生%5D%20Re-Avaritia-forge-1.20.1-1.3.9.6-release.jar%23310!/:?] {re:classloading}
	at committee.nova.mods.avaritia.core.io.TileIOHandler.handleActiveIO(TileIOHandler.java:84) ~[%5B无尽贪婪：重生%5D%20Re-Avaritia-forge-1.20.1-1.3.9.6-release.jar%23310!/:?] {re:classloading}
	at committee.nova.mods.avaritia.common.tile.NeutronCompressorTile.handleActiveIO(NeutronCompressorTile.java:314) ~[%5B无尽贪婪：重生%5D%20Re-Avaritia-forge-1.20.1-1.3.9.6-release.jar%23310!/:?] {re:classloading}
	at committee.nova.mods.avaritia.common.tile.NeutronCompressorTile.tick(NeutronCompressorTile.java:95) ~[%5B无尽贪婪：重生%5D%20Re-Avaritia-forge-1.20.1-1.3.9.6-release.jar%23310!/:?] {re:classloading}
	at moze_intel.projecte.gameObjs.items.rings.TimeWatch.speedUpBlockEntities(TimeWatch.java:151) ~[%5B等价交换重制版%5D%20ProjectE-1.20.1-PE1.0.1.jar%23328!/:1.0.1] {re:classloading}
	at moze_intel.projecte.gameObjs.items.rings.TimeWatch.updateInPedestal(TimeWatch.java:228) ~[%5B等价交换重制版%5D%20ProjectE-1.20.1-PE1.0.1.jar%23328!/:1.0.1] {re:classloading}
	at moze_intel.projecte.capability.PedestalItemCapabilityWrapper.updateInPedestal(PedestalItemCapabilityWrapper.java:25) ~[%5B等价交换重制版%5D%20ProjectE-1.20.1-PE1.0.1.jar%23328!/:1.0.1] {re:classloading}
	at moze_intel.projecte.gameObjs.block_entities.DMPedestalBlockEntity.tickServer(DMPedestalBlockEntity.java:77) ~[%5B等价交换重制版%5D%20ProjectE-1.20.1-PE1.0.1.jar%23328!/:1.0.1] {re:classloading}
	at net.minecraft.world.level.chunk.LevelChunk$BoundTickingBlockEntity.m_142224_(LevelChunk.java:689) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.world_border.DirectBlockEntityTickInvokerMixin,pl:mixin:A}
	at net.minecraft.world.level.chunk.LevelChunk$RebindableTickingBlockEntityWrapper.m_142224_(LevelChunk.java:782) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.world.level.Level.m_46463_(Level.java:468) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:computing_frames,pl:accesstransformer:B,xf:fml:twilightforest:cloud,re:mixin,pl:accesstransformer:B,xf:fml:twilightforest:cloud,re:classloading,pl:accesstransformer:B,xf:fml:twilightforest:cloud,pl:mixin:APP:tweakerge.mixins.json:MixinWorld,pl:mixin:APP:citadel.mixins.json:LevelMixin,pl:mixin:APP:botania_xplat.mixins.json:LevelAccessor,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.WorldMixin,pl:mixin:APP:lithium.mixins.json:entity.collisions.intersection.WorldMixin,pl:mixin:APP:lithium.mixins.json:util.block_entity_retrieval.WorldMixin,pl:mixin:APP:lithium.mixins.json:util.block_tracking.block_listening.WorldMixin,pl:mixin:APP:lithium.mixins.json:world.chunk_access.WorldMixin,pl:mixin:APP:lithium.mixins.json:world.inline_block_access.WorldMixin,pl:mixin:APP:lithium.mixins.json:world.inline_height.WorldMixin,pl:mixin:APP:starlight.mixins.json:common.world.LevelMixin,pl:mixin:A}
	at net.minecraft.server.level.ServerLevel.m_8793_(ServerLevel.java:351) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,xf:fml:libx:level_load,re:classloading,pl:accesstransformer:B,xf:fml:libx:level_load,pl:mixin:APP:xaeroworldmap.mixins.json:MixinServerWorld,pl:mixin:APP:citadel.mixins.json:ServerLevelMixin,pl:mixin:APP:modernfix-modernfix.mixins.json:perf.cache_strongholds.ServerLevelMixin,pl:mixin:APP:modernfix-modernfix.mixins.json:perf.faster_structure_location.ServerLevelMixin,pl:mixin:APP:botania_xplat.mixins.json:ServerLevelMixin,pl:mixin:APP:krypton.mixins.json:server.fastchunkentityaccess.ServerWorldMixin,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.ServerWorldMixin,pl:mixin:APP:lithium.mixins.json:chunk.entity_class_groups.ServerWorldAccessor,pl:mixin:APP:lithium.mixins.json:entity.inactive_navigations.ServerWorldMixin,pl:mixin:APP:lithium.mixins.json:profiler.ServerWorldMixin,pl:mixin:APP:lithium.mixins.json:util.entity_movement_tracking.ServerWorldAccessor,pl:mixin:APP:starlight.mixins.json:common.world.ServerWorldMixin,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:893) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:814) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at net.minecraft.client.server.IntegratedServer.m_5705_(IntegratedServer.java:89) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:mixin:APP:modernfix-modernfix.mixins.json:perf.thread_priorities.IntegratedServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:661) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_206580_(MinecraftServer.java:251) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at java.lang.Thread.run(Thread.java:1583) ~[?:?] {re:mixin,pl:accesstransformer:B}


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Thread: Render thread
Suspected Mods: 
	Re-Avaritia (avaritia), Version: 1.3.9.6
		Issue tracker URL: https://github.com/Nova-Committee/Re-Avaritia/issues
		at TRANSFORMER/avaritia@1.3.9.6/committee.nova.mods.avaritia.common.tile.NeutronCompressorTile.extractFromHandler(NeutronCompressorTile.java:394)

	ProjectE (projecte), Version: 1.0.1
		Issue tracker URL: https://github.com/sinkillerj/ProjectE/issues
		at TRANSFORMER/projecte@1.0.1/moze_intel.projecte.gameObjs.items.rings.TimeWatch.speedUpBlockEntities(TimeWatch.java:151)
Stacktrace:
	at committee.nova.mods.avaritia.common.tile.NeutronCompressorTile.extractFromHandler(NeutronCompressorTile.java:394) ~[%5B无尽贪婪：重生%5D%20Re-Avaritia-forge-1.20.1-1.3.9.6-release.jar%23310!/:?] {re:classloading}
	at committee.nova.mods.avaritia.core.io.TileIOHandler.lambda$handleActiveInput$0(TileIOHandler.java:112) ~[%5B无尽贪婪：重生%5D%20Re-Avaritia-forge-1.20.1-1.3.9.6-release.jar%23310!/:?] {re:classloading}
	at net.minecraftforge.common.util.LazyOptional.ifPresent(LazyOptional.java:137) ~[forge-1.20.1-47.4.16-universal.jar%23393!/:?] {re:mixin,re:classloading}
	at committee.nova.mods.avaritia.core.io.TileIOHandler.handleActiveInput(TileIOHandler.java:112) ~[%5B无尽贪婪：重生%5D%20Re-Avaritia-forge-1.20.1-1.3.9.6-release.jar%23310!/:?] {re:classloading}
	at committee.nova.mods.avaritia.core.io.TileIOHandler.handleActiveIO(TileIOHandler.java:84) ~[%5B无尽贪婪：重生%5D%20Re-Avaritia-forge-1.20.1-1.3.9.6-release.jar%23310!/:?] {re:classloading}
	at committee.nova.mods.avaritia.common.tile.NeutronCompressorTile.handleActiveIO(NeutronCompressorTile.java:314) ~[%5B无尽贪婪：重生%5D%20Re-Avaritia-forge-1.20.1-1.3.9.6-release.jar%23310!/:?] {re:classloading}
	at committee.nova.mods.avaritia.common.tile.NeutronCompressorTile.tick(NeutronCompressorTile.java:95) ~[%5B无尽贪婪：重生%5D%20Re-Avaritia-forge-1.20.1-1.3.9.6-release.jar%23310!/:?] {re:classloading}
	at moze_intel.projecte.gameObjs.items.rings.TimeWatch.speedUpBlockEntities(TimeWatch.java:151) ~[%5B等价交换重制版%5D%20ProjectE-1.20.1-PE1.0.1.jar%23328!/:1.0.1] {re:classloading}
	at moze_intel.projecte.gameObjs.items.rings.TimeWatch.updateInPedestal(TimeWatch.java:228) ~[%5B等价交换重制版%5D%20ProjectE-1.20.1-PE1.0.1.jar%23328!/:1.0.1] {re:classloading}
	at moze_intel.projecte.capability.PedestalItemCapabilityWrapper.updateInPedestal(PedestalItemCapabilityWrapper.java:25) ~[%5B等价交换重制版%5D%20ProjectE-1.20.1-PE1.0.1.jar%23328!/:1.0.1] {re:classloading}
	at moze_intel.projecte.gameObjs.block_entities.DMPedestalBlockEntity.tickServer(DMPedestalBlockEntity.java:77) ~[%5B等价交换重制版%5D%20ProjectE-1.20.1-PE1.0.1.jar%23328!/:1.0.1] {re:classloading}
	at net.minecraft.world.level.chunk.LevelChunk$BoundTickingBlockEntity.m_142224_(LevelChunk.java:689) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.world_border.DirectBlockEntityTickInvokerMixin,pl:mixin:A}
	at net.minecraft.world.level.chunk.LevelChunk$RebindableTickingBlockEntityWrapper.m_142224_(LevelChunk.java:782) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.world.level.Level.m_46463_(Level.java:468) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:computing_frames,pl:accesstransformer:B,xf:fml:twilightforest:cloud,re:mixin,pl:accesstransformer:B,xf:fml:twilightforest:cloud,re:classloading,pl:accesstransformer:B,xf:fml:twilightforest:cloud,pl:mixin:APP:tweakerge.mixins.json:MixinWorld,pl:mixin:APP:citadel.mixins.json:LevelMixin,pl:mixin:APP:botania_xplat.mixins.json:LevelAccessor,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.WorldMixin,pl:mixin:APP:lithium.mixins.json:entity.collisions.intersection.WorldMixin,pl:mixin:APP:lithium.mixins.json:util.block_entity_retrieval.WorldMixin,pl:mixin:APP:lithium.mixins.json:util.block_tracking.block_listening.WorldMixin,pl:mixin:APP:lithium.mixins.json:world.chunk_access.WorldMixin,pl:mixin:APP:lithium.mixins.json:world.inline_block_access.WorldMixin,pl:mixin:APP:lithium.mixins.json:world.inline_height.WorldMixin,pl:mixin:APP:starlight.mixins.json:common.world.LevelMixin,pl:mixin:A}
	at net.minecraft.server.level.ServerLevel.m_8793_(ServerLevel.java:351) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,xf:fml:libx:level_load,re:classloading,pl:accesstransformer:B,xf:fml:libx:level_load,pl:mixin:APP:xaeroworldmap.mixins.json:MixinServerWorld,pl:mixin:APP:citadel.mixins.json:ServerLevelMixin,pl:mixin:APP:modernfix-modernfix.mixins.json:perf.cache_strongholds.ServerLevelMixin,pl:mixin:APP:modernfix-modernfix.mixins.json:perf.faster_structure_location.ServerLevelMixin,pl:mixin:APP:botania_xplat.mixins.json:ServerLevelMixin,pl:mixin:APP:krypton.mixins.json:server.fastchunkentityaccess.ServerWorldMixin,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.ServerWorldMixin,pl:mixin:APP:lithium.mixins.json:chunk.entity_class_groups.ServerWorldAccessor,pl:mixin:APP:lithium.mixins.json:entity.inactive_navigations.ServerWorldMixin,pl:mixin:APP:lithium.mixins.json:profiler.ServerWorldMixin,pl:mixin:APP:lithium.mixins.json:util.entity_movement_tracking.ServerWorldAccessor,pl:mixin:APP:starlight.mixins.json:common.world.ServerWorldMixin,pl:mixin:A}
-- Block entity being ticked --
Details:
	Name: projecte:dm_pedestal // moze_intel.projecte.gameObjs.block_entities.DMPedestalBlockEntity
	Block: Block{projecte:dm_pedestal}[waterlogged=false]
	Block location: World: (100,79,626), Section: (at 4,15,2 in 6,4,39; chunk contains blocks 96,-64,624 to 111,319,639), Region: (0,1; contains chunks 0,32 to 31,63, blocks 0,-64,512 to 511,319,1023)
	Block: Block{projecte:dm_pedestal}[waterlogged=false]
	Block location: World: (100,79,626), Section: (at 4,15,2 in 6,4,39; chunk contains blocks 96,-64,624 to 111,319,639), Region: (0,1; contains chunks 0,32 to 31,63, blocks 0,-64,512 to 511,319,1023)
Stacktrace:
	at net.minecraft.world.level.chunk.LevelChunk$BoundTickingBlockEntity.m_142224_(LevelChunk.java:689) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.world_border.DirectBlockEntityTickInvokerMixin,pl:mixin:A}
	at net.minecraft.world.level.chunk.LevelChunk$RebindableTickingBlockEntityWrapper.m_142224_(LevelChunk.java:782) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.world.level.Level.m_46463_(Level.java:468) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:computing_frames,pl:accesstransformer:B,xf:fml:twilightforest:cloud,re:mixin,pl:accesstransformer:B,xf:fml:twilightforest:cloud,re:classloading,pl:accesstransformer:B,xf:fml:twilightforest:cloud,pl:mixin:APP:tweakerge.mixins.json:MixinWorld,pl:mixin:APP:citadel.mixins.json:LevelMixin,pl:mixin:APP:botania_xplat.mixins.json:LevelAccessor,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.WorldMixin,pl:mixin:APP:lithium.mixins.json:entity.collisions.intersection.WorldMixin,pl:mixin:APP:lithium.mixins.json:util.block_entity_retrieval.WorldMixin,pl:mixin:APP:lithium.mixins.json:util.block_tracking.block_listening.WorldMixin,pl:mixin:APP:lithium.mixins.json:world.chunk_access.WorldMixin,pl:mixin:APP:lithium.mixins.json:world.inline_block_access.WorldMixin,pl:mixin:APP:lithium.mixins.json:world.inline_height.WorldMixin,pl:mixin:APP:starlight.mixins.json:common.world.LevelMixin,pl:mixin:A}
	at net.minecraft.server.level.ServerLevel.m_8793_(ServerLevel.java:351) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,xf:fml:libx:level_load,re:classloading,pl:accesstransformer:B,xf:fml:libx:level_load,pl:mixin:APP:xaeroworldmap.mixins.json:MixinServerWorld,pl:mixin:APP:citadel.mixins.json:ServerLevelMixin,pl:mixin:APP:modernfix-modernfix.mixins.json:perf.cache_strongholds.ServerLevelMixin,pl:mixin:APP:modernfix-modernfix.mixins.json:perf.faster_structure_location.ServerLevelMixin,pl:mixin:APP:botania_xplat.mixins.json:ServerLevelMixin,pl:mixin:APP:krypton.mixins.json:server.fastchunkentityaccess.ServerWorldMixin,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.ServerWorldMixin,pl:mixin:APP:lithium.mixins.json:chunk.entity_class_groups.ServerWorldAccessor,pl:mixin:APP:lithium.mixins.json:entity.inactive_navigations.ServerWorldMixin,pl:mixin:APP:lithium.mixins.json:profiler.ServerWorldMixin,pl:mixin:APP:lithium.mixins.json:util.entity_movement_tracking.ServerWorldAccessor,pl:mixin:APP:starlight.mixins.json:common.world.ServerWorldMixin,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:893) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:814) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at net.minecraft.client.server.IntegratedServer.m_5705_(IntegratedServer.java:89) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:mixin:APP:modernfix-modernfix.mixins.json:perf.thread_priorities.IntegratedServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:661) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_206580_(MinecraftServer.java:251) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at java.lang.Thread.run(Thread.java:1583) ~[?:?] {re:mixin,pl:accesstransformer:B}


-- Affected level --
Details:
	All players: 2 total; [ServerPlayer['AiLiAnSong'/108, l='ServerLevel[新的世界]', x=113.04, y=78.00, z=616.25], ServerPlayer['Acdeasdff'/377, l='ServerLevel[新的世界]', x=97.20, y=78.63, z=625.31]]
	Chunk stats: 3617
	Level dimension: minecraft:overworld
	Level spawn location: World: (0,72,0), Section: (at 0,8,0 in 0,4,0; chunk contains blocks 0,-64,0 to 15,319,15), Region: (0,0; contains chunks 0,0 to 31,31, blocks 0,-64,0 to 511,319,511)
	Level time: 388150 game time, 434629 day time
	Level name: 新的世界
	Level game mode: Game mode: survival (ID 0). Hardcore: false. Cheats: true
	Level weather: Rain time: 70098 (now: false), thunder time: 74169 (now: false)
	Known server brands: forge
	Removed feature flags: 
	Level was modded: true
	Level storage version: 0x04ABD - Anvil
Stacktrace:
	at net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:893) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:814) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at net.minecraft.client.server.IntegratedServer.m_5705_(IntegratedServer.java:89) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:mixin:APP:modernfix-modernfix.mixins.json:perf.thread_priorities.IntegratedServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:661) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_206580_(MinecraftServer.java:251) ~[client-1.20.1-20230612.114412-srg.jar%23388!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at java.lang.Thread.run(Thread.java:1583) ~[?:?] {re:mixin,pl:accesstransformer:B}


-- System Details --
Details:
	Minecraft Version: 1.20.1
	Minecraft Version ID: 1.20.1
	Operating System: Windows 11 (amd64) version 10.0
	Java Version: 21.0.8, Azul Systems, Inc.
	Java VM Version: OpenJDK 64-Bit Server VM (mixed mode, sharing), Azul Systems, Inc.
	Memory: 2930490960 bytes (2794 MiB) / 9395240960 bytes (8960 MiB) up to 32212254720 bytes (30720 MiB)
	CPUs: 12
	Processor Vendor: AuthenticAMD
	Processor Name: AMD Ryzen 5 7500F 6-Core Processor             
	Identifier: AuthenticAMD Family 25 Model 97 Stepping 2
	Microarchitecture: Zen 3
	Frequency (GHz): 3.70
	Number of physical packages: 1
	Number of physical CPUs: 6
	Number of logical CPUs: 12
	Graphics card #0 name: AMD Radeon RX 9060 XT
	Graphics card #0 vendor: Advanced Micro Devices, Inc. (0x1002)
	Graphics card #0 VRAM (MB): 4095.00
	Graphics card #0 deviceId: 0x7590
	Graphics card #0 versionInfo: DriverVersion=32.0.23017.1001
	Memory slot #0 capacity (MB): 16384.00
	Memory slot #0 clockSpeed (GHz): 4.80
	Memory slot #0 type: Unknown
	Memory slot #1 capacity (MB): 16384.00
	Memory slot #1 clockSpeed (GHz): 4.80
	Memory slot #1 type: Unknown
	Virtual memory max (MB): 34409.99
	Virtual memory used (MB): 29290.20
	Swap memory total (MB): 2048.00
	Swap memory used (MB): 116.93
	JVM Flags: 6 total; -XX:+UseG1GC -XX:-UseAdaptiveSizePolicy -XX:-OmitStackTraceInFastThrow -XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump -Xmn4608m -Xmx30720m
	Loaded Shaderpack: (off)
	Server Running: true
	Player Count: 2 / 8; [ServerPlayer['AiLiAnSong'/108, l='ServerLevel[新的世界]', x=113.04, y=78.00, z=616.25], ServerPlayer['Acdeasdff'/377, l='ServerLevel[新的世界]', x=97.20, y=78.63, z=625.31]]
	Data Packs: vanilla, mod:geckolib, mod:slashblade, mod:projecte, mod:multimine (incompatible), mod:gpumemleakfix (incompatible), mod:controlling (incompatible), mod:xaeroworldmap (incompatible), mod:placebo (incompatible), mod:citadel (incompatible), mod:alexsmobs (incompatible), mod:modernfix (incompatible), mod:mangomultiblock (incompatible), mod:cloth_config (incompatible), mod:tinkercrossbowautofire, mod:twilightforest, mod:embeddium, mod:glodium (incompatible), mod:avaritia_integration, mod:do_a_barrel_roll (incompatible), mod:botania, mod:manapeeper (incompatible), mod:energyblade, mod:curios (incompatible), mod:patchouli (incompatible), mod:oculus, mod:searchables (incompatible), mod:ftbultimine (incompatible), mod:architectury (incompatible), mod:enchantmentlevelbreak, mod:transition, mod:tinkerleveling (incompatible), mod:dynamic_fps, mod:sridr, mod:mekanismupgradesreborn, mod:ante (incompatible), mod:packagedavaritia, mod:lradd (incompatible), mod:justenoughfuels, mod:radium, mod:ftblibrary (incompatible), mod:ftbteams (incompatible), mod:customskinloader (incompatible), mod:xaerolib (incompatible), mod:tacz, mod:murasame, mod:unifyeverything, mod:trender, mod:clumps (incompatible), mod:naturescompass, mod:mcwifipnp, mod:configured (incompatible), mod:moremekasuitunits, mod:libx, mod:voidminers (incompatible), mod:mana_jade, mod:starlight (incompatible), mod:guideme (incompatible), mod:explorerscompass, mod:projecteintegration, mod:memoryleakfix (incompatible), mod:puzzlesaccessapi, mod:ftbchunks (incompatible), mod:skinlayers3d, mod:forge, mod:uncraftable (incompatible), mod:slashblade_addon, mod:cofh_core, mod:thermal, mod:thermal_innovation, mod:thermal_foundation, mod:thermal_dynamics, mod:tconstruct (incompatible), mod:tinkersemc, mod:alexscaves, mod:tinker_in_caves, mod:appliede (incompatible), mod:mousetweaks, mod:configuration (incompatible), mod:avaritia, mod:jade (incompatible), mod:spectrelib (incompatible), mod:cao, mod:packagedauto, mod:tconjei, mod:resharped_renderfix_patch, mod:mantle (incompatible), mod:xaerominimap (incompatible), mod:thermal_cultivation, mod:polymorph (incompatible), mod:almostunified (incompatible), mod:jei, mod:ae2 (incompatible), mod:ae2wtlib (incompatible), mod:mekanism, mod:mekaweapons (incompatible), mod:mekanismgenerators, mod:mekanismtools, mod:mekmm, mod:expatternprovider (incompatible), mod:extendedae_plus, mod:mae2a, mod:advanced_ae (incompatible), mod:polyeng (incompatible), mod:jecharacters (incompatible), mod:appbot (incompatible), mod:ae2addonlib (incompatible), mod:fastfurnace (incompatible), mod:appleskin (incompatible), mod:ferritecore (incompatible), mod:addonapi, mod:ticex, mod:puzzleslib, mod:betterf3, mod:appmek (incompatible), mod:botanicalmachinery, mod:tconbreakthrough, mod:aewireless, mod:overflowingbars, tacz_resources, mod:tweakerge (incompatible), mod:mafglib, mod:inventoryprofilesnext (incompatible), mod:libipn (incompatible), mod:kotlinforforge (incompatible), mod:buildinggadgets2 (incompatible), mod:krypton (incompatible)
	Enabled Feature Flags: minecraft:vanilla
	World Generation: Experimental
	Type: Integrated Server (map_client.txt)
	Is Modded: Definitely; Client brand changed to 'forge'; Server brand changed to 'forge'
	Launched Version: 1.20.1-Forge_47.4.16-xjbw
	ModLauncher: 10.0.9+10.0.9+main.dcd20f30
	ModLauncher launch target: forgeclient
	ModLauncher naming: srg
	ModLauncher services: 
		mixin-0.8.5.jar mixin PLUGINSERVICE 
		eventbus-6.2.33.jar eventbus PLUGINSERVICE 
		fmlloader-1.20.1-47.4.16.jar slf4jfixer PLUGINSERVICE 
		fmlloader-1.20.1-47.4.16.jar object_holder_definalize PLUGINSERVICE 
		fmlloader-1.20.1-47.4.16.jar runtime_enum_extender PLUGINSERVICE 
		fmlloader-1.20.1-47.4.16.jar capability_token_subclass PLUGINSERVICE 
		accesstransformers-8.0.4.jar accesstransformer PLUGINSERVICE 
		fmlloader-1.20.1-47.4.16.jar runtimedistcleaner PLUGINSERVICE 
		modlauncher-10.0.9.jar mixin TRANSFORMATIONSERVICE 
		modlauncher-10.0.9.jar fml TRANSFORMATIONSERVICE 
	FML Language Providers: 
		minecraft@1.0
		lowcodefml@null
		kotlinforforge@4.12.0
		javafml@null
	Mod List: 
		geckolib-forge-1.20.1-4.8.3.jar                   |GeckoLib 4                    |geckolib                      |4.8.3               |DONE      |Manifest: NOSIGNATURE
		[拔刀剑：重锋] SlashBladeResharped-1.20.1-1.8.62.jar    |Slash Blade:Resharped         |slashblade                    |1.8.62              |DONE      |Manifest: NOSIGNATURE
		[等价交换重制版] ProjectE-1.20.1-PE1.0.1.jar             |ProjectE                      |projecte                      |1.0.1               |DONE      |Manifest: NOSIGNATURE
		[多人开采] multimine-1.20.1.4.jar                     |Multi Mine                    |multimine                     |1.20.1.4            |DONE      |Manifest: NOSIGNATURE
		[修复GPU内存泄漏] gpumemleakfix-1.20.1-1.8.jar          |Gpu memory leak fix           |gpumemleakfix                 |1.20.1-1.8          |DONE      |Manifest: NOSIGNATURE
		[键位冲突显示] Controlling-forge-1.20.1-12.0.2.jar      |Controlling                   |controlling                   |12.0.2              |DONE      |Manifest: NOSIGNATURE
		[Xaero的世界地图] xaeroworldmap-forge-1.20.1-1.40.11.ja|Xaero's World Map             |xaeroworldmap                 |1.40.11             |DONE      |Manifest: NOSIGNATURE
		Placebo-1.20.1-8.6.3.jar                          |Placebo                       |placebo                       |8.6.3               |DONE      |Manifest: NOSIGNATURE
		citadel-2.6.3-1.20.1.jar                          |Citadel                       |citadel                       |2.6.3               |DONE      |Manifest: NOSIGNATURE
		[Alex 的生物] alexsmobs-1.22.9.jar                   |Alex's Mobs                   |alexsmobs                     |1.22.9              |DONE      |Manifest: NOSIGNATURE
		[现代化修复] modernfix-forge-5.26.2+mc1.20.1.jar       |ModernFix                     |modernfix                     |5.26.2+mc1.20.1     |DONE      |Manifest: NOSIGNATURE
		Tweakerge-0.1.5-mc1.20.1.jar                      |Tweakerge                     |tweakerge                     |0.1.5-mc1.20.1      |DONE      |Manifest: NOSIGNATURE
		mangomultiblock-1.20.1-1.3.0.jar                  |mangomultiblock               |mangomultiblock               |1.3.0               |DONE      |Manifest: NOSIGNATURE
		cloth-config-11.1.136-forge.jar                   |Cloth Config v10 API          |cloth_config                  |11.1.136            |DONE      |Manifest: NOSIGNATURE
		tinkercrossbowautofire-1.0-SNAPSHOT.jar           |TinkerCrossbowAutoFire        |tinkercrossbowautofire        |1.0-SNAPSHOT        |DONE      |Manifest: NOSIGNATURE
		[暮色森林] twilightforest-1.20.1-4.3.2508-universal.ja|The Twilight Forest           |twilightforest                |4.3.2508            |DONE      |Manifest: NOSIGNATURE
		embeddium-0.3.31+mc1.20.1.jar                     |Embeddium                     |embeddium                     |0.3.31+mc1.20.1     |DONE      |Manifest: NOSIGNATURE
		Glodium-1.20-1.5-forge.jar                        |Glodium                       |glodium                       |1.20-1.5-forge      |DONE      |Manifest: NOSIGNATURE
		AvaritiaIntegration-forge-1.20.1-1.0.2-release.jar|AvaritiaIntegration           |avaritia_integration          |1.0.2               |DONE      |Manifest: NOSIGNATURE
		do_a_barrel_roll-forge-3.5.6+1.20.1.jar           |Do a Barrel Roll              |do_a_barrel_roll              |3.5.6+1.20.1        |DONE      |Manifest: NOSIGNATURE
		MaFgLib-0.1.14-mc1.20.1.jar                       |MaFgLib                       |mafglib                       |0.1.14-mc1.20.1     |DONE      |Manifest: NOSIGNATURE
		[植物魔法] Botania-1.20.1-450-FORGE.jar               |Botania                       |botania                       |1.20.1-450-FORGE    |DONE      |Manifest: NOSIGNATURE
		ManaPeeper-1.4+1.20.1-forge.jar                   |Mana Peeper                   |manapeeper                    |1.4+1.20.1-forge    |DONE      |Manifest: NOSIGNATURE
		[拔刀剑：高频刀] energyblade-1.1.5-1.20.1.jar            |HF Blade                      |energyblade                   |1.1.5-1.20.1        |DONE      |Manifest: NOSIGNATURE
		curios-forge-5.14.1+1.20.1.jar                    |Curios API                    |curios                        |5.14.1+1.20.1       |DONE      |Manifest: NOSIGNATURE
		[帕秋莉手册] Patchouli-1.20.1-84.1-FORGE.jar           |Patchouli                     |patchouli                     |1.20.1-84.1-FORGE   |DONE      |Manifest: NOSIGNATURE
		oculus-mc1.20.1-1.8.0.jar                         |Oculus                        |oculus                        |1.8.0               |DONE      |Manifest: NOSIGNATURE
		Searchables-forge-1.20.1-1.0.3.jar                |Searchables                   |searchables                   |1.0.3               |DONE      |Manifest: NOSIGNATURE
		[连锁破坏] ftb-ultimine-forge-2001.1.7.jar            |FTB Ultimine                  |ftbultimine                   |2001.1.7            |DONE      |Manifest: NOSIGNATURE
		[一键背包整理Next] InventoryProfilesNext-forge-1.20-1.10|Inventory Profiles Next       |inventoryprofilesnext         |1.10.20             |DONE      |Manifest: NOSIGNATURE
		architectury-9.2.14-forge.jar                     |Architectury                  |architectury                  |9.2.14              |DONE      |Manifest: NOSIGNATURE
		[附魔等级上限突破2] EnchantmentLevelBreak-1.20.1-Forge-1.5|EnchantmentLevelBreak         |enchantmentlevelbreak         |1.5                 |DONE      |Manifest: NOSIGNATURE
		TRansition-1.0.11-1.20.1-forge-SNAPSHOT.jar       |TRansition                    |transition                    |1.0.11              |DONE      |Manifest: NOSIGNATURE
		tinkerleveling-0.4.0.jar                          |Tinker Leveling               |tinkerleveling                |0.4.0               |DONE      |Manifest: NOSIGNATURE
		[动态 FPS] dynamic-fps-3.11.4+minecraft-1.20.0-forge|Dynamic FPS                   |dynamic_fps                   |3.11.4              |DONE      |Manifest: NOSIGNATURE
		sridr-1.1.jar                                     |sridr                         |sridr                         |1.1                 |DONE      |Manifest: NOSIGNATURE
		mekanismupgradesreborn-1.20.1-5.0.0.jar           |Mekanism Upgrades: Reborn     |mekanismupgradesreborn        |1.20.1-5.0.0        |DONE      |Manifest: NOSIGNATURE
		AnvilNeverTooExpensive-1.20.1-1.1.jar             |Anvil Never Too Expensive     |ante                          |1.1                 |DONE      |Manifest: NOSIGNATURE
		[封包无尽贪婪] PackagedAvaritia-Re-1.20.1-2.2.2.13.jar  |PackagedAvaritia:Re           |packagedavaritia              |2.2.2.13            |DONE      |Manifest: NOSIGNATURE
		[氪Forge版] KryptonReforged-0.2.3.jar               |Krypton Reforged              |krypton                       |0.2.3               |DONE      |Manifest: NOSIGNATURE
		[TaC：绿葡萄附属包] lradd-1.20.1-0.3.0.jar               |LesRaisinsAddon               |lradd                         |0.3.0               |DONE      |Manifest: NOSIGNATURE
		JustEnoughFuel-0.1.0.jar                          |Just Enough Fuels             |justenoughfuels               |0.1.0               |DONE      |Manifest: NOSIGNATURE
		[镭] radium-mc1.20.1-0.12.4+git.26c9d8e.jar        |Radium                        |radium                        |0.12.4+git.26c9d8e  |DONE      |Manifest: NOSIGNATURE
		ftb-library-forge-2001.2.12.jar                   |FTB Library                   |ftblibrary                    |2001.2.12           |DONE      |Manifest: NOSIGNATURE
		[FTB 团队] ftb-teams-forge-2001.3.2.jar             |FTB Teams                     |ftbteams                      |2001.3.2            |DONE      |Manifest: NOSIGNATURE
		[万用皮肤补丁] CustomSkinLoader_ForgeV2-14.27.jar       |CustomSkinLoader              |customskinloader              |14.27               |DONE      |Manifest: 4a:31:8b:cf:34:eb:d0:13:f3:19:39:d5:d2:b9:12:78:b5:f2:8d:91:3e:6f:8f:ed:97:48:00:69:e1:30:3a:54
		xaerolib-forge-1.20.1-1.1.0.jar                   |XaeroLib                      |xaerolib                      |1.1.0               |DONE      |Manifest: NOSIGNATURE
		[永恒枪械工坊：零] tacz-1.20.1-1.1.7-hotfix.jar           |Timeless & Classics Guns: Zero|tacz                          |1.1.7-hotfix        |DONE      |Manifest: NOSIGNATURE
		[拔刀剑：丛雨丸] murasame-1.1.3.jar                      |Murasame                      |murasame                      |1.1.3               |DONE      |Manifest: NOSIGNATURE
		unifyeverything-1.20.1-1.0.2.9.jar                |Almost Unify Everything       |unifyeverything               |1.0.2.9             |DONE      |Manifest: NOSIGNATURE
		TRender-1.0.10-1.20.1-forge-SNAPSHOT.jar          |TRender                       |trender                       |1.0.10              |DONE      |Manifest: NOSIGNATURE
		[经验机制改革] Clumps-forge-1.20.1-12.0.0.4.jar         |Clumps                        |clumps                        |12.0.0.4            |DONE      |Manifest: NOSIGNATURE
		[自然罗盘／生物群系指南针] NaturesCompass-1.20.1-1.11.2-forge.|Nature's Compass              |naturescompass                |1.20.1-1.11.2-forge |DONE      |Manifest: NOSIGNATURE
		[更高级联机设置] mcwifipnp-1.7.6-1.20.1-forge.jar        |LAN World Plug-n-Play         |mcwifipnp                     |1.7.6               |DONE      |Manifest: NOSIGNATURE
		[配置界面] configured-forge-1.20.1-2.2.3.jar          |Configured                    |configured                    |2.2.3               |DONE      |Manifest: 0d:78:5f:44:c0:47:0c:8c:e2:63:a3:04:43:d4:12:7d:b0:7c:35:37:dc:40:b1:c1:98:ec:51:eb:3b:3c:45:99
		[通用机械：更多单元] moremekasuitunits-1.2-release-all.jar |Mekanism:MoreModules          |moremekasuitunits             |1.2-release         |DONE      |Manifest: NOSIGNATURE
		LibX-1.20.1-5.0.14.jar                            |LibX                          |libx                          |1.20.1-5.0.14       |DONE      |Manifest: NOSIGNATURE
		voidminers-1.20.1-1.9.25.3.jar                    |Void Miners                   |voidminers                    |1.20.1-1.9.25.3     |DONE      |Manifest: NOSIGNATURE
		[以玉定植] mana_jade-1.2.1.jar                        |Mana Jade                     |mana_jade                     |1.2.1               |DONE      |Manifest: NOSIGNATURE
		[星光] starlight-1.1.2+forge.1cda73c.jar            |Starlight                     |starlight                     |1.1.2+forge.1cda73c |DONE      |Manifest: NOSIGNATURE
		guideme-20.1.14.jar                               |GuideME                       |guideme                       |20.1.14             |DONE      |Manifest: NOSIGNATURE
		[探险者指南针] ExplorersCompass-1.20.1-1.3.3-forge.jar  |Explorer's Compass            |explorerscompass              |1.20.1-1.3.3-forge  |DONE      |Manifest: NOSIGNATURE
		[等价兼容] ProjectE_Integration-1.20.1-7.2.5.jar      |ProjectE Integration          |projecteintegration           |7.2.5               |DONE      |Manifest: NOSIGNATURE
		[内存泄漏修复] memoryleakfix-forge-1.17+-1.1.5.jar      |Memory Leak Fix               |memoryleakfix                 |1.1.5               |DONE      |Manifest: NOSIGNATURE
		puzzlesaccessapi-forge-20.1.1.jar                 |Puzzles Access Api            |puzzlesaccessapi              |20.1.1              |DONE      |Manifest: NOSIGNATURE
		[FTB 区块] ftb-chunks-forge-2001.3.6.jar            |FTB Chunks                    |ftbchunks                     |2001.3.6            |DONE      |Manifest: NOSIGNATURE
		[3D 皮肤层] skinlayers3d-forge-1.10.1-mc1.20.1.jar   |3d-Skin-Layers                |skinlayers3d                  |1.10.1              |DONE      |Manifest: NOSIGNATURE
		forge-1.20.1-47.4.16-universal.jar                |Forge                         |forge                         |47.4.16             |DONE      |Manifest: NOSIGNATURE
		[失落配方] rotl-4.12-1.20.1-forge.jar                 |Recipes of the Lost           |uncraftable                   |4.12                |DONE      |Manifest: NOSIGNATURE
		[拔刀剑日系附属包] SJAP_Resharpened-1.20.1-1.2.16.jar     |SlashBlade Japanese Addon Pack|slashblade_addon              |1.2.16              |DONE      |Manifest: NOSIGNATURE
		client-1.20.1-20230612.114412-srg.jar             |Minecraft                     |minecraft                     |1.20.1              |DONE      |Manifest: a1:d4:5e:04:4f:d3:d6:e0:7b:37:97:cf:77:b0:de:ad:4a:47:ce:8c:96:49:5f:0a:cf:8c:ae:b2:6d:4b:8a:3f
		[CoFH核心] cofh_core-1.20.1-11.0.2.56.jar           |CoFH Core                     |cofh_core                     |11.0.2              |DONE      |Manifest: NOSIGNATURE
		thermal_core-1.20.1-11.0.6.24.jar                 |Thermal Series                |thermal                       |11.0.6              |DONE      |Manifest: NOSIGNATURE
		[热力革新] thermal_innovation-1.20.1-11.0.1.23.jar    |Thermal Innovation            |thermal_innovation            |11.0.1              |DONE      |Manifest: NOSIGNATURE
		[热力基本] thermal_foundation-1.20.1-11.0.6.70.jar    |Thermal Foundation            |thermal_foundation            |11.0.6              |DONE      |Manifest: NOSIGNATURE
		[热动力学] thermal_dynamics-1.20.1-11.0.1.23.jar      |Thermal Dynamics              |thermal_dynamics              |11.0.1              |DONE      |Manifest: NOSIGNATURE
		[匠魂] TConstruct-1.20.1-3.11.2.166.jar             |Tinkers' Construct            |tconstruct                    |3.11.2.166          |DONE      |Manifest: NOSIGNATURE
		[匠魂EMC] TconEmc-0.1.3-debug.jar                   |Tinkers' emc                  |tinkersemc                    |0.1.3-debug         |DONE      |Manifest: NOSIGNATURE
		[Alex 的洞穴] alexscaves-2.0.2.jar                   |Alex's Caves                  |alexscaves                    |2.0.2               |DONE      |Manifest: NOSIGNATURE
		[洞穴工匠] tinker_in_caves-1.0.4.jar                  |Tinker in Caves               |tinker_in_caves               |1.0.4               |DONE      |Manifest: NOSIGNATURE
		libIPN-forge-1.20-4.0.2.jar                       |libIPN                        |libipn                        |4.0.2               |DONE      |Manifest: NOSIGNATURE
		appliede-0.14.3.jar                               |AppliedE                      |appliede                      |0.14.3              |DONE      |Manifest: NOSIGNATURE
		[鼠标手势] MouseTweaks-forge-mc1.20.1-2.25.1.jar      |Mouse Tweaks                  |mousetweaks                   |2.25.1              |DONE      |Manifest: NOSIGNATURE
		configuration-444699-5840405.jar                  |Configuration                 |configuration                 |3.1.0               |DONE      |Manifest: NOSIGNATURE
		[无尽贪婪：重生] Re-Avaritia-forge-1.20.1-1.3.9.6-release|Re-Avaritia                   |avaritia                      |1.3.9.6             |DONE      |Manifest: NOSIGNATURE
		[玉 ?] Jade-1.20.1-Forge-11.13.2.jar              |Jade                          |jade                          |11.13.2+forge       |DONE      |Manifest: NOSIGNATURE
		spectrelib-forge-0.13.17+1.20.1.jar               |SpectreLib                    |spectrelib                    |0.13.17+1.20.1      |DONE      |Manifest: NOSIGNATURE
		[槽] cao-3.7.0.jar                                 |槽 (Cao)                       |cao                           |3.6.0               |DONE      |Manifest: NOSIGNATURE
		[封包合成] PackagedAuto-1.20.1-3.4.15.46.jar          |PackagedAuto                  |packagedauto                  |3.4.15.46           |DONE      |Manifest: NOSIGNATURE
		tconjei-1.20.1-1.5.1.jar                          |TConJEI                       |tconjei                       |1.5.1               |DONE      |Manifest: NOSIGNATURE
		[拔刀剑：重锋 渲染修复补丁] resharped_renderfix_patch-1.0.1.ja|SlashBlade Resharped RenderFix|resharped_renderfix_patch     |1.0.1               |DONE      |Manifest: NOSIGNATURE
		kffmod-4.12.0.jar                                 |Kotlin For Forge              |kotlinforforge                |4.12.0              |DONE      |Manifest: NOSIGNATURE
		[地幔] Mantle-1.20.1-1.11.104.jar                   |Mantle                        |mantle                        |1.11.104            |DONE      |Manifest: NOSIGNATURE
		[Xaero的小地图] xaerominimap-forge-1.20.1-25.3.10.jar |Xaero's Minimap               |xaerominimap                  |25.3.10             |DONE      |Manifest: NOSIGNATURE
		[热力农业] thermal_cultivation-1.20.1-11.0.1.24.jar   |Thermal Cultivation           |thermal_cultivation           |11.0.1              |DONE      |Manifest: NOSIGNATURE
		[多态合成] polymorph-forge-0.49.10+1.20.1.jar         |Polymorph                     |polymorph                     |0.49.10+1.20.1      |DONE      |Manifest: NOSIGNATURE
		almostunified-forge-1.20.1-0.11.0.jar             |AlmostUnified                 |almostunified                 |1.20.1-0.11.0       |DONE      |Manifest: NOSIGNATURE
		[JEI物品管理器] jei-1.20.1-forge-15.20.0.129.jar       |Just Enough Items             |jei                           |15.20.0.129         |DONE      |Manifest: NOSIGNATURE
		[应用能源2] appliedenergistics2-forge-15.4.10.jar     |Applied Energistics 2         |ae2                           |15.4.10             |DONE      |Manifest: NOSIGNATURE
		[AE2无线终端] ae2wtlib-15.3.3-forge.jar               |AE2WTLib                      |ae2wtlib                      |15.3.3-forge        |DONE      |Manifest: NOSIGNATURE
		[通用机械] Mekanism-1.20.1-10.4.16.80.jar             |Mekanism                      |mekanism                      |10.4.16             |DONE      |Manifest: NOSIGNATURE
		[通用机械武器] MekanismWeapons-1.20.1-3.0.jar           |Mekanism: Weapons             |mekaweapons                   |3.0                 |DONE      |Manifest: NOSIGNATURE
		[通用机械发电机] MekanismGenerators-1.20.1-10.4.16.80.jar|Mekanism: Generators          |mekanismgenerators            |10.4.16             |DONE      |Manifest: NOSIGNATURE
		[通用机械工具] MekanismTools-1.20.1-10.4.16.80.jar      |Mekanism: Tools               |mekanismtools                 |10.4.16             |DONE      |Manifest: NOSIGNATURE
		[通用机械：更多机器] mekmm-1.20.1-1.1.2.jar                |Mekanism: More Machine        |mekmm                         |1.1.2               |DONE      |Manifest: NOSIGNATURE
		[AE2扩展] ExtendedAE-1.20-1.4.10-forge.jar          |ExtendedAE                    |expatternprovider             |1.20-1.4.10-forge   |DONE      |Manifest: NOSIGNATURE
		extendedae_plus-1.5.1.jar                         |ExtendedAE Plus               |extendedae_plus               |1.5.1               |DONE      |Manifest: NOSIGNATURE
		more-ae2-additions-1.0.8-1.20.1.jar               |More AE2 Additions            |mae2a                         |1.0.8               |DONE      |Manifest: NOSIGNATURE
		[高级AE] AdvancedAE-1.3.2-1.20.1.jar                |Advanced AE                   |advanced_ae                   |1.3.2-1.20.1        |DONE      |Manifest: NOSIGNATURE
		polyeng-forge-0.1.1-1.20.1.jar                    |Polymorphic Energistics       |polyeng                       |0.1.1-1.20.1        |DONE      |Manifest: NOSIGNATURE
		[通用拼音搜索] jecharacters-1.20.1-forge-4.6.3.jar      |Just Enough Characters        |jecharacters                  |4.6.3               |DONE      |Manifest: NOSIGNATURE
		[应用能源：植物魔法附属] applied-botanics-forge-1.5.2.jar    |Applied Botanics              |appbot                        |1.5.2               |DONE      |Manifest: NOSIGNATURE
		[建筑小帮手] buildinggadgets2-1.0.8.jar                |Building Gadgets 2            |buildinggadgets2              |1.0.8               |DONE      |Manifest: NOSIGNATURE
		ae2addonlib-1.0.3-1.20.1.jar                      |AE2AddonLib                   |ae2addonlib                   |1.0.3-1.20.1        |DONE      |Manifest: NOSIGNATURE
		[熔炉性能优化] FastFurnace-1.20.1-8.0.2.jar             |FastFurnace                   |fastfurnace                   |8.0.2               |DONE      |Manifest: NOSIGNATURE
		[苹果皮] appleskin-forge-mc1.20.1-2.5.1.jar          |AppleSkin                     |appleskin                     |2.5.1+mc1.20.1      |DONE      |Manifest: NOSIGNATURE
		[铁氧体磁芯] ferritecore-6.0.1-forge.jar               |Ferrite Core                  |ferritecore                   |6.0.1               |DONE      |Manifest: 41:ce:50:66:d1:a0:05:ce:a1:0e:02:85:9b:46:64:e0:bf:2e:cf:60:30:9a:fe:0c:27:e0:63:66:9a:84:ce:8a
		addonapi-mc1.20.1-2.0.0-SNAPSHOT.jar              |AddonAPI                      |addonapi                      |2.0.0-SNAPSHOT      |DONE      |Manifest: NOSIGNATURE
		ticex-mc1.20.1-0.5.0-SNAPSHOT-3hotfix-all.jar     |TiCEX                         |ticex                         |0.5.0-SNAPSHOT-3hotf|DONE      |Manifest: NOSIGNATURE
		PuzzlesLib-v8.1.33-1.20.1-Forge.jar               |Puzzles Lib                   |puzzleslib                    |8.1.33              |DONE      |Manifest: 9a:09:85:98:65:c4:8c:11:c5:49:f6:d6:33:23:39:df:8d:b4:ff:92:84:b8:bd:a5:83:9f:ac:7f:2a:d1:4b:6a
		[更好的F3] BetterF3-7.0.2-Forge-1.20.1.jar           |BetterF3                      |betterf3                      |7.0.2               |DONE      |Manifest: NOSIGNATURE
		[应用能源：通用机械附属] Applied-Mekanistics-1.4.3.jar       |Applied Mekanistics           |appmek                        |1.4.3               |DONE      |Manifest: NOSIGNATURE
		[植物机械] BotanicalMachinery-1.20.1-3.0.8.jar        |Botanical Machinery           |botanicalmachinery            |1.20.1-3.0.8        |DONE      |Manifest: NOSIGNATURE
		tconbreakthrough-1.4.jar                          |Tconbreakthrough              |tconbreakthrough              |1.4                 |DONE      |Manifest: NOSIGNATURE
		[AE无线收发器] aewireless-1.2.5.jar                    |AE Wireless                   |aewireless                    |1.2.5               |DONE      |Manifest: NOSIGNATURE
		OverflowingBars-v8.0.1-1.20.1-Forge.jar           |Overflowing Bars              |overflowingbars               |8.0.1               |DONE      |Manifest: 9a:09:85:98:65:c4:8c:11:c5:49:f6:d6:33:23:39:df:8d:b4:ff:92:84:b8:bd:a5:83:9f:ac:7f:2a:d1:4b:6a
	Crash Report UUID: be361c18-e768-4555-9aee-df2d725e99c5
	FML: 47.4
	Forge: net.minecraftforge:47.4.16

