### PR TITLE
修复非当前压缩配方物品无法从槽位中取出的问题

### DIFF
--- a/src/main/java/committee/nova/mods/avaritia/api/common/slot/ItemStackWrapperSlot.java
+++ b/src/main/java/committee/nova/mods/avaritia/api/common/slot/ItemStackWrapperSlot.java
@@ -1,30 +1,48 @@
 package committee.nova.mods.avaritia.api.common.slot;
 
 import committee.nova.mods.avaritia.api.common.wrapper.ItemStackWrapper;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.items.SlotItemHandler;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Description:
- * Author: cnlimiter
- * Date: 2022/4/2 18:12
- * Version: 1.0
+ * @author cnlimiter
  */
-public class ItemStackWrapperSlot extends SlotItemHandler {
+public class ItemStackWrapperSlot extends SlotItemHandler
+{
     private final ItemStackWrapper inventory;
     private final int index;
 
-    public ItemStackWrapperSlot(ItemStackWrapper inventory, int index, int xPosition, int yPosition) {
-        super(inventory, index, xPosition, yPosition);
+    public ItemStackWrapperSlot(ItemStackWrapper inventory, int index, int x, int y) {
+        super(inventory, index, x, y);
         this.inventory = inventory;
         this.index = index;
     }
 
+    @Override
+    public boolean mayPickup(Player player) {
+        return !this.inventory.extractItem(this.index, 1, true, true).isEmpty();
+    }
 
     @Override
     public @NotNull ItemStack remove(int amount) {
-        return this.inventory.extractItem(this.index, amount, false);
+        return this.inventory.extractItem(this.index, amount, false, true);
     }
 
+    @Override
+    public int getMaxStackSize(@NotNull ItemStack stack) {
+        var slotLimit = this.inventory.getSlotLimit(this.index);
+        if (slotLimit > 64) {
+            // if the max size for the stack is less than 64 then we should decrease the max stack size to the
+            // same ratio
+            if (stack.getMaxStackSize() < 64) {
+                return (int) (slotLimit * (float) stack.getMaxStackSize() / 64);
+            }
+
+            return slotLimit;
+        }
+
+        return super.getMaxStackSize(stack);
+    }
 }

--- a/src/main/java/committee/nova/mods/avaritia/common/menu/NeutronCompressorMenu.java
+++ b/src/main/java/committee/nova/mods/avaritia/common/menu/NeutronCompressorMenu.java
@@ -2,6 +2,7 @@ package committee.nova.mods.avaritia.common.menu;
 
 import committee.nova.mods.avaritia.api.common.crafting.ShapelessCraftingInput;
 import committee.nova.mods.avaritia.api.common.menu.BaseTileMenu;
+import committee.nova.mods.avaritia.api.common.slot.ItemStackWrapperSlot;
 import committee.nova.mods.avaritia.api.common.slot.OutputSlot;
 import committee.nova.mods.avaritia.api.common.wrapper.ItemStackWrapper;
 import committee.nova.mods.avaritia.common.tile.NeutronCompressorTile;
@@ -15,7 +16,6 @@ import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.inventory.SimpleContainerData;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeHolder;
-import net.neoforged.neoforge.items.SlotItemHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -63,7 +63,7 @@ public class NeutronCompressorMenu extends BaseTileMenu<NeutronCompressorTile> {
             return true;
         });
         this.addSlot(new OutputSlot(inventory, 0, 120, 35));
-        this.addSlot(new SlotItemHandler(inventory, 1, 39, 35));
+        this.addSlot(new ItemStackWrapperSlot(inventory, 1, 39, 35));
         createInventorySlots(playerInventory);
     }
 


### PR DESCRIPTION
复现方式：
首先使用压缩机压缩铁奇点，在有压缩进度时，放入金锭。此时金锭无法取出，压缩机卡死