### PR TITLE
[Bug] fix(chest): fix NPE when loading InfinityChestTile on client side

### DIFF
--- a/src/main/java/committee/nova/mods/avaritia/common/block/chest/InfinityChestBlock.java
+++ b/src/main/java/committee/nova/mods/avaritia/common/block/chest/InfinityChestBlock.java
@@ -48,6 +48,9 @@ import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import org.apache.logging.log4j.LogManager;  
+import org.apache.logging.log4j.Logger;  
+
 import java.util.List;
 import java.util.UUID;
 
@@ -55,6 +58,8 @@ import java.util.UUID;
  * @author cnlimiter
  */
 public class InfinityChestBlock extends BaseTileEntityBlock implements SimpleWaterloggedBlock {
+    private static final Logger LOGGER = LogManager.getLogger();
+    
     public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
     public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
     protected static final VoxelShape AABB = Block.box(1.0D, 0.0D, 1.0D, 15.0D, 14.0D, 15.0D);
@@ -126,6 +131,11 @@ public class InfinityChestBlock extends BaseTileEntityBlock implements SimpleWat
         if (pStack.getTag().contains("BlockEntityTag")) {
             CompoundTag nbt = pStack.getTag().getCompound("BlockEntityTag");
             if (nbt.contains("owner") && nbt.contains("channelID")) {
+                ServerChestManager manager = ServerChestManager.getInstance();  
+                if (manager == null) {  
+                    LOGGER.warn("[InfinityChestBlock] ServerChestManager is null in appendHoverText(), skipping tooltip content.");  
+                    return;
+                }
                 var owner = nbt.getUUID("owner");
                 var channelID = nbt.getUUID("channelID");
                 var channel = ServerChestManager.getInstance().getChest(owner, channelID);

--- a/src/main/java/committee/nova/mods/avaritia/common/tile/InfinityChestTile.java
+++ b/src/main/java/committee/nova/mods/avaritia/common/tile/InfinityChestTile.java
@@ -5,6 +5,7 @@ import committee.nova.mods.avaritia.api.util.lang.Localizable;
 import committee.nova.mods.avaritia.common.menu.InfinityChestMenu;
 import committee.nova.mods.avaritia.core.chest.ServerChestHandler;
 import committee.nova.mods.avaritia.core.chest.ServerChestManager;
+import committee.nova.mods.avaritia.core.chest.ServerChestManager;
 import committee.nova.mods.avaritia.init.registry.ModTileEntities;
 import lombok.Getter;
 import net.minecraft.core.BlockPos;
@@ -26,6 +27,9 @@ import net.minecraftforge.common.util.LazyOptional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import org.apache.logging.log4j.LogManager;  
+import org.apache.logging.log4j.Logger;
+
 import java.util.UUID;
 
 /**
@@ -46,6 +50,8 @@ public class InfinityChestTile extends BaseTileEntity implements LidBlockEntity 
     private ServerChestHandler channel = new ServerChestHandler();
     @Getter
     private LazyOptional<?> capability = LazyOptional.of(() -> channel);
+    
+    private static final Logger LOGGER = LogManager.getLogger();
 
     public InfinityChestTile(BlockPos pos, BlockState state) {
         super(ModTileEntities.infinity_chest_tile.get(), pos, state);
@@ -61,6 +67,17 @@ public class InfinityChestTile extends BaseTileEntity implements LidBlockEntity 
     public @Nullable AbstractContainerMenu createMenu(int containerId, @NotNull Inventory playerInventory, @NotNull Player player) {
         return new InfinityChestMenu(containerId, player, this);
     }
+    
+    @Override  
+    public void handleUpdateTag(CompoundTag tag) {  
+        if (tag.contains("owner")) {  
+            owner = tag.getUUID("owner");  
+            locked = tag.getBoolean("locked");  
+        }  
+        if (tag.contains("filter")) filter = tag.getString("filter");  
+        if (tag.contains("sortType")) sortType = tag.getByte("sortType");  
+        if (tag.contains("channelID")) channelID = tag.getUUID("channelID");  
+    }
 
     @Override
     public void load(@NotNull CompoundTag pTag) {
@@ -71,7 +88,12 @@ public class InfinityChestTile extends BaseTileEntity implements LidBlockEntity 
         if (pTag.contains("filter")) filter = pTag.getString("filter");
         if (pTag.contains("sortType")) sortType = pTag.getByte("sortType");
         if (pTag.contains("channelID")) channelID = pTag.getUUID("channelID");
-        channel = ServerChestManager.getInstance().getChest(owner, channelID);
+        ServerChestManager manager = ServerChestManager.getInstance();  
+        if (manager == null) {  
+            LOGGER.warn("[InfinityChestTile] ServerChestManager is null during load(), skipping channel binding. pos={}", getBlockPos());  
+            return;  
+        }  
+        channel = manager.getChest(owner, channelID);  
     }
 
     @Override

--- a/src/main/java/committee/nova/mods/avaritia/core/chest/ServerChestManager.java
+++ b/src/main/java/committee/nova/mods/avaritia/core/chest/ServerChestManager.java
@@ -18,6 +18,9 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.server.ServerLifecycleHooks;
 
+import org.apache.logging.log4j.LogManager;  
+import org.apache.logging.log4j.Logger;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
@@ -28,10 +31,17 @@ import java.util.UUID;
  */
 @Mod.EventBusSubscriber(modid = Const.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class ServerChestManager {
+    private static final Logger LOGGER = LogManager.getLogger();
+    
     private static volatile ServerChestManager instance;
 
     public static ServerChestManager getInstance() {
         if (instance == null) {
+            MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
+            if (server == null) {  
+                LOGGER.warn("[ServerChestManager] getInstance() called but no server is running (client-side?). Returning null.");  
+                return null;  
+            }
             synchronized (ServerChestManager.class) {
                 if (instance == null) {
                     instance = new ServerChestManager(ServerLifecycleHooks.getCurrentServer());


### PR DESCRIPTION
<!--
  New Feature or Bug Fix Pull Request
    新功能或错误修复拉取请求
  Implement an idea for this project or implement a bug fix to help us improve.
    为本项目实现一个想法或修复一个错误，以帮助我们改进。

  Insert "[Enhancement] " or "[Bug] " before the first word in the title.
    在标题的第一个词前插入「[Enhancement] 」或「[Bug]」。
  Note that the PR may be closed directly if you do not follow the instructions.
    请注意，如果不按说明操作，拉取请求可能会被直接关闭。
-->
done

### Checks / 检查

<!-- 
  Please check that you have done the following things before submitting a pull request.
    在提交请求之前，请检查您是否已完成以下操作。
  
  Set [ ] to [X]
    将 [ ]设置为 [X]
-->

- [X] I confirm that I have [searched for existing issues / pull requests](https://github.com/cnlimiter/McBot/issues?q=) before requesting to avoid duplicate requesting.  
      我确认在报告之前我已经搜索了[现有的问题或者拉取请求](https://github.com/cnlimiter/McBot/issues?q=)，以避免重复报告。
- [X] I confirm that I noted that if I don't follow the instructions, the issue may be closed directly.  
      我确认我已经检查，如果我不按照说明进行操作，该问题可能会被直接关闭。

### Related Issues / 相关的 GitHub 问题

<!--
  Any GitHub issues related to this PR? If not, please fill in "N/A".
    是否有与此拉取请求相关的任何 GitHub 问题？如果没有，请填写「N/A」。
  
  Example: Fix #ISSUE-NUMBER
    示例：修复 #问题编号
-->

Fix #332 

### Description / 描述

<!--
  For Bug Fix Pull Request:
    用于错误修复的拉取请求：
  Please tell us what bug have you fixed with a clear and detailed description, add screenshots to help explain.
    请告诉我们您修复了哪些错误，并提供清晰详细的描述，并添加截图以帮助解释。
  
  For New Feature Pull Request:
    用于新功能的拉取请求：
  What new feature or change have you added? What does it improve? Please tell us what the new feature or change is with a clear and detailed description, add screenshots to help explain if possible.
    您添加了哪些新功能或更改？它有什么改善？请告诉我们新功能或更改是什么，并提供清晰详细的描述，如果可能，请添加截图以帮助解释。
-->
https://github.com/Nova-Committee/Re-Avaritia/commit/7cbb4273ddab729cbf6c7b231579780c02bd53c0

在多人联机游戏中（纯客户端），客户端收到服务器发来的区块数据包后，会在客户端线程上调用 InfinityChestTile.load() 来解析方块实体的 NBT 标签。
InfinityChestTile.load() 在第 74 行无条件调用了 ServerChestManager.getInstance()
而 getInstance() 在 instance == null 时 会通过 ServerLifecycleHooks.getCurrentServer() 获取服务器实例
在多人游戏的纯客户端 ServerLifecycleHooks.getCurrentServer() 返回 null（客户端根本没有本地服务器） 结果用 null 构造了 ServerChestManager(null)
构造函数调用 this.load() 在第 92 行访问 server.getWorldPath(...) 时 server 为 null，即发生空指针

- 在 InfinityChestTile 中重写 handleUpdateTag() 方法，防止客户端在接收区块数据包时访问 ServerChestManager
- 在 ServerChestManager.getInstance() 中添加空值保护，当没有服务器运行时（客户端环境）返回 null，防止 load() 方法中出现空指针异常
- 在 InfinityChestBlock.appendHoverText() 中添加空值保护，当 ServerChestManager 不可用时跳过提示文本渲染
- 我顺便写了 LOGGER.WARN 以便确认是否还出现了空值的传递 但实际上没有再出现了 你可以查看以下日志
[afterfix-minecraft-exported-logs-2026-02-27T13-05-20.log](https://github.com/user-attachments/files/25596194/afterfix-minecraft-exported-logs-2026-02-27T13-05-20.log)

我已经确认此修复已经能够解决此问题 如图：
<img width="1920" height="1080" alt="Image_1772172813280" src="https://github.com/user-attachments/assets/ff14114b-30c1-42d1-a5e8-3ee2b8e3ab79" />
