### PR TITLE
[Bug] 修复在多人联机状态下，连接到服务器的玩家，在查询携带nbt的无尽之箱的tooltip会造成崩端问题

### DIFF
--- a/src/main/java/committee/nova/mods/avaritia/common/block/chest/InfinityChestBlock.java
+++ b/src/main/java/committee/nova/mods/avaritia/common/block/chest/InfinityChestBlock.java
@@ -131,14 +131,14 @@ public class InfinityChestBlock extends BaseTileEntityBlock implements SimpleWat
         if (pStack.getTag().contains("BlockEntityTag")) {
             CompoundTag nbt = pStack.getTag().getCompound("BlockEntityTag");
             if (nbt.contains("owner") && nbt.contains("channelID")) {
-                ServerChestManager manager = ServerChestManager.getInstance();  
-                if (manager == null) {  
+                ServerChestManager manager = ServerChestManager.getInstance();
+                if (manager == null) {
                     LOGGER.warn("[InfinityChestBlock] ServerChestManager is null in appendHoverText(), skipping tooltip content.");  
                     return;
                 }
                 var owner = nbt.getUUID("owner");
                 var channelID = nbt.getUUID("channelID");
-                var channel = ServerChestManager.getInstance().getChest(owner, channelID);
+                var channel = manager.getChest(owner, channelID);
                 int i = 0;
                 int j = 0;
                 for (var item : channel.storageItems.keySet()) {

--- a/src/main/java/committee/nova/mods/avaritia/core/chest/ServerChestManager.java
+++ b/src/main/java/committee/nova/mods/avaritia/core/chest/ServerChestManager.java
@@ -20,6 +20,7 @@ import net.minecraftforge.server.ServerLifecycleHooks;
 
 import org.apache.logging.log4j.LogManager;  
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,16 +36,17 @@ public class ServerChestManager {
     
     private static volatile ServerChestManager instance;
 
+    @Nullable
     public static ServerChestManager getInstance() {
         if (instance == null) {
             MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
-            if (server == null) {  
-                LOGGER.warn("[ServerChestManager] getInstance() called but no server is running (client-side?). Returning null.");  
-                return null;  
+            if (server == null) {
+                LOGGER.warn("[ServerChestManager] getInstance() called but no server is running (client-side?). Returning null.");
+                return null;
             }
             synchronized (ServerChestManager.class) {
                 if (instance == null) {
-                    instance = new ServerChestManager(ServerLifecycleHooks.getCurrentServer());
+                    instance = new ServerChestManager(server);
                 }
             }
         }


### PR DESCRIPTION
### Checks / 检查

- [X] I confirm that I have [searched for existing issues / pull requests](https://github.com/cnlimiter/McBot/issues?q=) before requesting to avoid duplicate requesting.  
      我确认在报告之前我已经搜索了[现有的问题或者拉取请求](https://github.com/cnlimiter/McBot/issues?q=)，以避免重复报告。
- [X] I confirm that I noted that if I don't follow the instructions, the issue may be closed directly.  
      我确认我已经检查，如果我不按照说明进行操作，该问题可能会被直接关闭。

### Related Issues / 相关的 GitHub 问题

Fix #338 

### Description / 描述

修复了在多人联机状态下，连接到服务器的玩家，在查询携带nbt标签的 **无尽之箱(Infinity Chest)** 的tooltip时，客户端会崩端的问题。

#### Cause Of The Problem / 问题原因

在玩家查询 **无尽之箱(Infinity Chest)** 的tooltip时，当目标物品携带`owner`和`channelID`标签时，客户端就会尝试获取箱子的内容，在多人联机状态下，连接到服务器的玩家的客户端，在使用`ServerChestManager.getInstance().getChest(owner, channelID)`获取箱子实例的时候，会调用`ServerChestManager`的`getInstance`，其中会使用`instance = new ServerChestManager(ServerLifecycleHooks.getCurrentServer());`创建实例，没有检测`ServerLifecycleHooks.getCurrentServer()`为空的情况，导致`load`使用`server.getWorldPath(LevelResource.ROOT)`时调用的`server`变量为空值，抛出NPE。

#### Solution / 解决方案

修复`ServerLifecycleHooks.getCurrentServer()`和`ServerChestManager.getInstance()`的空值判断。

#### Other Problem / 其它问题

没有找到`ServerLifecycleHooks.getCurrentServer()`通过了空值判断，但实际使用时仍为空值的原因。

```
MinecraftServer server = ServerLifecycleHooks.getCurrentServer();   // 非空
if (server == null) {
    LOGGER.warn("[ServerChestManager] getInstance() called but no server is running (client-side?). Returning null.");
    return null;
}
synchronized (ServerChestManager.class) {
    if (instance == null) {
        instance = new ServerChestManager(ServerLifecycleHooks.getCurrentServer());   // 空
    }
}
```