### PR TITLE
fix: infinity elytra compat with elytra slot mod.

### DIFF
--- a/src/main/java/committee/nova/mods/avaritia/Const.java
+++ b/src/main/java/committee/nova/mods/avaritia/Const.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.mojang.authlib.GameProfile;
 import committee.nova.mods.avaritia.api.util.data.RawValue;
+import committee.nova.mods.avaritia.init.compat.curios.CuriosTools;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
@@ -13,14 +14,9 @@ import net.minecraftforge.fml.ModList;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import top.theillusivec4.curios.api.CuriosApi;
-import top.theillusivec4.curios.api.SlotResult;
 
 import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -61,13 +57,11 @@ public class Const {
         return ForgeRegistries.ITEMS.getKey(item);
     }
 
+    // do not use curios api here or we will break something
     public static <T> T checkExtraSlots(Player player, Predicate<ItemStack> is, T def, Function<ItemStack, T> map) {
         if (curios) {
-            AtomicReference<List<SlotResult>> s = new AtomicReference<>(new ArrayList<>());
-            CuriosApi.getCuriosInventory(player).ifPresent(curiosInventory -> {
-                s.set(curiosInventory.findCurios(is));
-            });
-            if (!s.get().isEmpty()) return map.apply(s.get().get(0).stack());
+            ItemStack stack = CuriosTools.getFirstItemFromCuriosInv(player, is);
+            if (!stack.isEmpty()) return map.apply(stack);
         }
         return def;
     }

--- a/src/main/java/committee/nova/mods/avaritia/client/AvaritiaForgeClient.java
+++ b/src/main/java/committee/nova/mods/avaritia/client/AvaritiaForgeClient.java
@@ -10,7 +10,7 @@ import committee.nova.mods.avaritia.common.item.singularity.SingularityItem;
 import committee.nova.mods.avaritia.common.net.C2SElytraSpeedUpPacket;
 import committee.nova.mods.avaritia.init.config.ModConfig;
 import committee.nova.mods.avaritia.init.handler.NetworkHandler;
-import committee.nova.mods.avaritia.init.registry.ModItems;
+import committee.nova.mods.avaritia.util.InfinityElytraUtils;
 import committee.nova.mods.avaritia.util.ToolUtils;
 import net.minecraft.client.Camera;
 import net.minecraft.client.KeyMapping;
@@ -23,7 +23,6 @@ import net.minecraft.nbt.NumericTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.FogType;
@@ -123,7 +122,7 @@ public class AvaritiaForgeClient {
             return;
         }
 
-        if (!player.getItemBySlot(EquipmentSlot.CHEST).is(ModItems.infinity_elytra.get())) {
+        if (!InfinityElytraUtils.hasInfinityElytraEquipped(player)) {
             resetInfinityElytraControls();
             return;
         }

--- a/src/main/java/committee/nova/mods/avaritia/client/render/entity/InfinityElytraLayer.java
+++ b/src/main/java/committee/nova/mods/avaritia/client/render/entity/InfinityElytraLayer.java
@@ -1,28 +1,64 @@
 package committee.nova.mods.avaritia.client.render.entity;
 
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
 import committee.nova.mods.avaritia.Res;
-import committee.nova.mods.avaritia.init.registry.ModItems;
+import committee.nova.mods.avaritia.util.InfinityElytraUtils;
+import net.minecraft.client.model.ElytraModel;
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.geom.EntityModelSet;
+import net.minecraft.client.model.geom.ModelLayers;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.client.renderer.entity.RenderLayerParent;
-import net.minecraft.client.renderer.entity.layers.ElytraLayer;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.client.renderer.entity.layers.RenderLayer;
+import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-public class InfinityElytraLayer<T extends LivingEntity, M extends EntityModel<T>> extends ElytraLayer<T, M> {
+public class InfinityElytraLayer<T extends LivingEntity, M extends EntityModel<T>> extends RenderLayer<T, M> {
+    private final ElytraModel<T> elytraModel;
+
     public InfinityElytraLayer(RenderLayerParent<T, M> pRenderer, EntityModelSet pModelSet) {
-        super(pRenderer, pModelSet);
+        super(pRenderer);
+        this.elytraModel = new ElytraModel<>(pModelSet.bakeLayer(ModelLayers.ELYTRA));
     }
 
+    /**
+    * Seperate render logics, cause it's directly on PlayerModel, so just change it's render way will fix everything
+    * @author  HowXu <dev@howxu.cn>
+    */
     @Override
-    public boolean shouldRender(ItemStack stack, @NotNull T entity) {
-        return stack.is(ModItems.infinity_elytra.get());
+    public void render(@NotNull PoseStack poseStack, @NotNull MultiBufferSource buffer, int packedLight,
+                       @NotNull T livingEntity, float limbSwing, float limbSwingAmount, float partialTicks,
+                       float ageInTicks, float netHeadYaw, float headPitch) {
+        ItemStack stack = getInfinityElytraStack(livingEntity);
+        if (stack.isEmpty()) {
+            return;
+        }
+
+        poseStack.pushPose();
+        poseStack.translate(0.0D, 0.0D, 0.125D);
+        this.getParentModel().copyPropertiesTo(this.elytraModel);
+        this.elytraModel.setupAnim(livingEntity, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch);
+        VertexConsumer vertexconsumer = ItemRenderer.getArmorFoilBuffer(
+                buffer,
+                RenderType.armorCutoutNoCull(Res.INFINITY_ELYTRA),
+                false,
+                stack.hasFoil()
+        );
+        this.elytraModel.renderToBuffer(poseStack, vertexconsumer, packedLight, OverlayTexture.NO_OVERLAY,
+                1.0F, 1.0F, 1.0F, 1.0F);
+        poseStack.popPose();
     }
 
-    @Override
-    public @NotNull ResourceLocation getElytraTexture(@NotNull ItemStack stack, @NotNull T entity) {
-        return Res.INFINITY_ELYTRA;
+    private ItemStack getInfinityElytraStack(T livingEntity) {
+        if (livingEntity instanceof Player player) {
+            return InfinityElytraUtils.getInfinityElytraStack(player);
+        }
+        return ItemStack.EMPTY;
     }
 }

--- a/src/main/java/committee/nova/mods/avaritia/common/item/misc/InfinityElytraItem.java
+++ b/src/main/java/committee/nova/mods/avaritia/common/item/misc/InfinityElytraItem.java
@@ -1,9 +1,11 @@
 package committee.nova.mods.avaritia.common.item.misc;
 
 import committee.nova.mods.avaritia.init.config.ModConfig;
+import committee.nova.mods.avaritia.init.compat.curios.InfinityElytraCuriosCompat;
 import committee.nova.mods.avaritia.init.registry.ModDamageTypes;
 import committee.nova.mods.avaritia.init.registry.ModRarities;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
@@ -13,7 +15,10 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.fml.ModList;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class InfinityElytraItem extends ElytraItem {
     public InfinityElytraItem() {
@@ -87,5 +92,14 @@ public class InfinityElytraItem extends ElytraItem {
     @Override
     public boolean canElytraFly(@NotNull ItemStack stack, @NotNull LivingEntity entity) {
         return true;
+    }
+
+    @Nullable
+    @Override
+    public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt) {
+        if (ModList.get().isLoaded("curios")) {
+            return InfinityElytraCuriosCompat.createProvider(stack);
+        }
+        return super.initCapabilities(stack, nbt);
     }
 }

--- a/src/main/java/committee/nova/mods/avaritia/common/item/misc/InfinityElytraItem.java
+++ b/src/main/java/committee/nova/mods/avaritia/common/item/misc/InfinityElytraItem.java
@@ -4,6 +4,7 @@ import committee.nova.mods.avaritia.init.config.ModConfig;
 import committee.nova.mods.avaritia.init.compat.curios.InfinityElytraCuriosCompat;
 import committee.nova.mods.avaritia.init.registry.ModDamageTypes;
 import committee.nova.mods.avaritia.init.registry.ModRarities;
+import committee.nova.mods.avaritia.Const;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.RandomSource;
@@ -97,7 +98,7 @@ public class InfinityElytraItem extends ElytraItem {
     @Nullable
     @Override
     public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt) {
-        if (ModList.get().isLoaded("curios")) {
+        if (Const.curios) {
             return InfinityElytraCuriosCompat.createProvider(stack);
         }
         return super.initCapabilities(stack, nbt);

--- a/src/main/java/committee/nova/mods/avaritia/common/net/C2SElytraSpeedUpPacket.java
+++ b/src/main/java/committee/nova/mods/avaritia/common/net/C2SElytraSpeedUpPacket.java
@@ -1,14 +1,13 @@
 package committee.nova.mods.avaritia.common.net;
 
 import committee.nova.mods.avaritia.init.config.ModConfig;
-import committee.nova.mods.avaritia.init.registry.ModItems;
+import committee.nova.mods.avaritia.util.InfinityElytraUtils;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.effect.MobEffects;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.network.NetworkEvent;
 
@@ -42,7 +41,7 @@ public class C2SElytraSpeedUpPacket {
         context.enqueueWork(() -> {
             ServerPlayer player = context.getSender();
             if (player == null) return;
-            if (!player.getItemBySlot(EquipmentSlot.CHEST).is(ModItems.infinity_elytra.get())) return;
+            if (!InfinityElytraUtils.hasInfinityElytraEquipped(player)) return;
             if (!customFlying) return;
 
             boolean fallFlying = ensureFallFlying(player, boosting);

--- a/src/main/java/committee/nova/mods/avaritia/init/compat/curios/InfinityElytraCuriosCompat.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/compat/curios/InfinityElytraCuriosCompat.java
@@ -1,0 +1,69 @@
+package committee.nova.mods.avaritia.init.compat.curios;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.registries.ForgeRegistries;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.SlotContext;
+import top.theillusivec4.curios.api.type.capability.ICurio;
+
+import java.util.UUID;
+
+/**
+ * Add Single Curios Compat for infinity elytra
+ * @author  HowXu <dev@howxu.cn>
+ */
+public class InfinityElytraCuriosCompat {
+    // special register for caelus which provides a elytra modifier api
+    private static final ResourceLocation CAELUS_FALL_FLYING = new ResourceLocation("caelus", "fall_flying");
+
+    public static ICapabilityProvider createProvider(ItemStack stack) {
+        return CuriosApi.createCurioProvider(new ICurio() {
+            @Override
+            public ItemStack getStack() {
+                return stack;
+            }
+
+            @Override
+            public void curioTick(SlotContext slotContext) {
+                LivingEntity entity = slotContext.entity();
+                int ticks = entity.getFallFlyingTicks();
+                if (ticks > 0 && entity.isFallFlying()) {
+                    stack.elytraFlightTick(entity, ticks);
+                }
+            }
+
+            @Override
+            public Multimap<Attribute, AttributeModifier> getAttributeModifiers(SlotContext slotContext, UUID uuid) {
+                Multimap<Attribute, AttributeModifier> modifiers = HashMultimap.create();
+                Attribute fallFlying = ForgeRegistries.ATTRIBUTES.getValue(CAELUS_FALL_FLYING);
+                if (fallFlying != null) {
+                    modifiers.put(fallFlying, new AttributeModifier(uuid, "Infinity elytra curio modifier", 1.0D, AttributeModifier.Operation.ADDITION));
+                }
+                return modifiers;
+            }
+
+            @Override
+            public boolean canEquip(SlotContext slotContext) {
+                return true;
+            }
+
+            @Override
+            public SoundInfo getEquipSound(SlotContext slotContext) {
+                return new SoundInfo(SoundEvents.ARMOR_EQUIP_ELYTRA, 1.0F, 1.0F);
+            }
+
+            @Override
+            public boolean canEquipFromUse(SlotContext slotContext) {
+                return true;
+            }
+        });
+    }
+}

--- a/src/main/java/committee/nova/mods/avaritia/init/handler/InfinityHandler.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/handler/InfinityHandler.java
@@ -10,6 +10,7 @@ import committee.nova.mods.avaritia.common.item.tools.infinity.*;
 import committee.nova.mods.avaritia.common.net.S2CTotemPack;
 import committee.nova.mods.avaritia.init.config.ModConfig;
 import committee.nova.mods.avaritia.init.registry.*;
+import committee.nova.mods.avaritia.util.InfinityElytraUtils;
 import committee.nova.mods.avaritia.util.ToolUtils;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.resources.language.I18n;
@@ -25,7 +26,6 @@ import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -281,7 +281,7 @@ public class InfinityHandler {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void onInfinityElytraFall(LivingFallEvent event) {
         if (event.getEntity() instanceof Player player
-                && player.getItemBySlot(EquipmentSlot.CHEST).is(ModItems.infinity_elytra.get())) {
+                && InfinityElytraUtils.hasInfinityElytraEquipped(player)) {
             event.setDistance(0.0F);
             event.setDamageMultiplier(0.0F);
             player.resetFallDistance();
@@ -353,7 +353,7 @@ public class InfinityHandler {
     }
 
     private static boolean isUsingInfinityElytra(Player player) {
-        return player.getItemBySlot(EquipmentSlot.CHEST).is(ModItems.infinity_elytra.get())
+        return InfinityElytraUtils.hasInfinityElytraEquipped(player)
                 && (player.isFallFlying() || !player.onGround());
     }
 

--- a/src/main/java/committee/nova/mods/avaritia/util/InfinityElytraUtils.java
+++ b/src/main/java/committee/nova/mods/avaritia/util/InfinityElytraUtils.java
@@ -2,6 +2,7 @@ package committee.nova.mods.avaritia.util;
 
 import committee.nova.mods.avaritia.init.compat.curios.CuriosTools;
 import committee.nova.mods.avaritia.init.registry.ModItems;
+import committee.nova.mods.avaritia.Const;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -25,7 +26,7 @@ public class InfinityElytraUtils {
     }
 
     private static ItemStack findInfinityElytraInCurios(Player player) {
-        if (!ModList.get().isLoaded("curios")) {
+        if (!Const.curios) {
             return ItemStack.EMPTY;
         }
         return CuriosTools.getFirstItemFromCuriosInv(player, InfinityElytraUtils::isInfinityElytra);

--- a/src/main/java/committee/nova/mods/avaritia/util/InfinityElytraUtils.java
+++ b/src/main/java/committee/nova/mods/avaritia/util/InfinityElytraUtils.java
@@ -1,0 +1,37 @@
+package committee.nova.mods.avaritia.util;
+
+import committee.nova.mods.avaritia.init.compat.curios.CuriosTools;
+import committee.nova.mods.avaritia.init.registry.ModItems;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fml.ModList;
+
+/**
+ * Seperate logics of infinity elytra checking from single chest to both curios and equipment
+ * @author  HowXu <dev@howxu.cn>
+ */
+public class InfinityElytraUtils {
+    public static boolean hasInfinityElytraEquipped(Player player) {
+        return !getInfinityElytraStack(player).isEmpty();
+    }
+
+    public static ItemStack getInfinityElytraStack(Player player) {
+        ItemStack chestStack = player.getItemBySlot(EquipmentSlot.CHEST);
+        if (isInfinityElytra(chestStack)) {
+            return chestStack;
+        }
+        return findInfinityElytraInCurios(player);
+    }
+
+    private static ItemStack findInfinityElytraInCurios(Player player) {
+        if (!ModList.get().isLoaded("curios")) {
+            return ItemStack.EMPTY;
+        }
+        return CuriosTools.getFirstItemFromCuriosInv(player, InfinityElytraUtils::isInfinityElytra);
+    }
+
+    private static boolean isInfinityElytra(ItemStack stack) {
+        return stack.is(ModItems.infinity_elytra.get());
+    }
+}


### PR DESCRIPTION
<!--
  New Feature or Bug Fix Pull Request
    新功能或错误修复拉取请求
  Implement an idea for this project or implement a bug fix to help us improve.
    为本项目实现一个想法或修复一个错误，以帮助我们改进。

  Insert "[Enhancement] " or "[Bug] " before the first word in the title.
    在标题的第一个词前插入「[Enhancement] 」或「[Bug]」。
  Note that the PR may be closed directly if you do not follow the instructions.
    请注意，如果不按说明操作，拉取请求可能会被直接关闭。
-->

### Checks / 检查

<!-- 
  Please check that you have done the following things before submitting a pull request.
    在提交请求之前，请检查您是否已完成以下操作。
  
  Set [ ] to [X]
    将 [ ]设置为 [X]
-->

- [X] I confirm that I have [searched for existing issues / pull requests](https://github.com/cnlimiter/McBot/issues?q=) before requesting to avoid duplicate requesting.  
      我确认在报告之前我已经搜索了[现有的问题或者拉取请求](https://github.com/cnlimiter/McBot/issues?q=)，以避免重复报告。
- [X] I confirm that I noted that if I don't follow the instructions, the issue may be closed directly.  
      我确认我已经检查，如果我不按照说明进行操作，该问题可能会被直接关闭。

### Related Issues / 相关的 GitHub 问题

#313 

<!--
  Any GitHub issues related to this PR? If not, please fill in "N/A".
    是否有与此拉取请求相关的任何 GitHub 问题？如果没有，请填写「N/A」。
  
  Example: Fix #ISSUE-NUMBER
    示例：修复 #问题编号
-->

### Description / 描述

<!--
  For Bug Fix Pull Request:
    用于错误修复的拉取请求：
  Please tell us what bug have you fixed with a clear and detailed description, add screenshots to help explain.
    请告诉我们您修复了哪些错误，并提供清晰详细的描述，并添加截图以帮助解释。
  
  For New Feature Pull Request:
    用于新功能的拉取请求：
  What new feature or change have you added? What does it improve? Please tell us what the new feature or change is with a clear and detailed description, add screenshots to help explain if possible.
    您添加了哪些新功能或更改？它有什么改善？请告诉我们新功能或更改是什么，并提供清晰详细的描述，如果可能，请添加截图以帮助解释。
-->

add shared infinity elytra lookup for chest and Curios slots  
use shared lookup for client flight packets, server packet validation, fall damage, and flight protection  
add isolated Curios compatibility provider for infinity elytra  
call elytraFlightTick from Curios tick while fall flying  
expose Caelus fall_flying modifier when the attribute exists  
render infinity elytra for both curios and chest  
move direct Curios lookup in Const through CuriosTools to prevent api complex  

these changes do not influent any logics now existing, without elytra everything wil work still fine  

close #313

video here:

https://github.com/user-attachments/assets/b8672ff7-dfef-4356-b081-67a601888efb
